### PR TITLE
feat: postFilterString for filter parser post-filters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "phpstan/phpstan": "^1.9",
         "spatie/ray": "^1.1",
         "brianium/paratest": "^6.3",
-        "rachidlaasri/travel": "^1.06",
+        "rachidlaasri/travel": "^1.0.6",
         "symfony/dotenv": "^7.0",
         "rector/rector": "^1.2",
         "laravel/pint": "^1.25"

--- a/src/Query/NewQuery.php
+++ b/src/Query/NewQuery.php
@@ -65,6 +65,8 @@ class NewQuery implements MultiSearchable, Queries
     {
         $this->properties = $props instanceof NewProperties ? $props->get() : $props;
 
+        $this->search->filterParserProperties($this->properties);
+
         return $this;
     }
 
@@ -116,6 +118,11 @@ class NewQuery implements MultiSearchable, Queries
     public function postFilter(Query $postFilter): Search
     {
         return $this->search->postFilter($postFilter);
+    }
+
+    public function postFilterString(string $filterString): Search
+    {
+        return $this->search->postFilterString($filterString);
     }
 
     public function matchNone(float $boost = 1): Search

--- a/src/Query/Search.php
+++ b/src/Query/Search.php
@@ -8,6 +8,8 @@ use Http\Promise\Promise;
 use Sigmie\Base\APIs\Search as APIsSearch;
 use Sigmie\Base\Contracts\ElasticsearchConnection;
 use Sigmie\Base\Http\Responses\Search as SearchResponse;
+use Sigmie\Mappings\Properties;
+use Sigmie\Parse\FilterParser;
 use Sigmie\Query\Contracts\QueryClause as Query;
 use Sigmie\Query\Queries\MatchAll;
 
@@ -44,6 +46,8 @@ class Search
     protected Query $query;
 
     protected ?Query $postFilter = null;
+
+    protected ?Properties $filterParserProperties = null;
 
     protected Aggs $aggs;
 
@@ -219,6 +223,20 @@ class Search
         $this->postFilter = $postFilter;
 
         return $this;
+    }
+
+    public function filterParserProperties(Properties $properties): static
+    {
+        $this->filterParserProperties = $properties;
+
+        return $this;
+    }
+
+    public function postFilterString(string $filterString): static
+    {
+        $parser = new FilterParser($this->filterParserProperties ?? new Properties);
+
+        return $this->postFilter($parser->parse($filterString));
     }
 
     public function aggs(Aggs $aggs): static

--- a/tests/AggregationTest.php
+++ b/tests/AggregationTest.php
@@ -277,6 +277,37 @@ class AggregationTest extends TestCase
     /**
      * @test
      */
+    public function post_filter_string_filters_hits(): void
+    {
+        $name = uniqid();
+
+        $blueprint = new NewProperties;
+        $blueprint->keyword('status');
+
+        $this->sigmie->newIndex($name)
+            ->properties($blueprint)
+            ->create();
+
+        $collection = $this->sigmie->collect($name, refresh: true);
+
+        $collection->merge([
+            new Document(['status' => 'published']),
+            new Document(['status' => 'draft']),
+            new Document(['status' => 'published']),
+        ]);
+
+        $response = $this->sigmie->newQuery($name)
+            ->properties($blueprint)
+            ->matchAll()
+            ->postFilterString('status:"published"')
+            ->get();
+
+        $this->assertEquals(2, $response->json('hits.total.value'));
+    }
+
+    /**
+     * @test
+     */
     public function post_filter_omitted_when_not_set(): void
     {
         $name = uniqid();


### PR DESCRIPTION
## What changed

Adds `postFilterString(string)` so filter strings are parsed with `FilterParser` and applied as Elasticsearch `post_filter`, parallel to `postFilter(Query)`.

## How it works

- `Search` stores optional mapping context via `filterParserProperties(Properties)` and exposes `postFilterString()`.
- `NewQuery::properties()` forwards mappings to the inner `Search` so chaining `properties()->matchAll()->postFilterString(...)` uses the same types as `parse()`.

## Testing

- `post_filter_string_filters_hits` in `AggregationTest`: indexes docs, runs `matchAll()->postFilterString('status:"published"')`, asserts hit count.

## Notes

`src/Mappings/NewProperties.php` has a separate local change and was not included in this PR.

Made with [Cursor](https://cursor.com)