### PR TITLE
feat: add Sigmie::createForCloud() for simplified Elastic Cloud auth

### DIFF
--- a/src/Sigmie.php
+++ b/src/Sigmie.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sigmie;
 
+use Elastic\Transport\TransportBuilder;
+use GuzzleHttp\Client as GuzzleHttpClient;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Psr7\Uri;
 use Sigmie\AI\Contracts\EmbeddingsApi;
@@ -208,6 +210,23 @@ class Sigmie
         } catch (ConnectException) {
             return false;
         }
+    }
+
+    public static function createForCloud(
+        string $cloudId,
+        string $apiKey
+    ): static {
+        $transport = TransportBuilder::create()
+            ->setCloudId($cloudId)
+            ->setClient(new GuzzleHttpClient([
+                'allow_redirects' => false,
+                'http_errors' => false,
+                'connect_timeout' => 15,
+                'headers' => ['Authorization' => 'ApiKey '.$apiKey],
+            ]))
+            ->build();
+
+        return new static(new HttpConnection(new JSONClient($transport), new Elasticsearch));
     }
 
     public static function create(

--- a/src/Sigmie.php
+++ b/src/Sigmie.php
@@ -229,6 +229,17 @@ class Sigmie
         return new static(new HttpConnection(new JSONClient($transport), new Elasticsearch));
     }
 
+    public static function createForServerless(
+        string $host,
+        string $apiKey
+    ): static {
+        $client = JSONClient::create([$host], [
+            'headers' => ['Authorization' => 'ApiKey '.$apiKey],
+        ]);
+
+        return new static(new HttpConnection($client, new Elasticsearch));
+    }
+
     public static function create(
         array|string $hosts,
         SearchEngineType $engine = SearchEngineType::Elasticsearch,

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -10,10 +10,23 @@ use Psr\Http\Message\ResponseInterface;
 use Sigmie\Http\JSONRequest;
 use Sigmie\Http\JSONResponse;
 use Sigmie\Http\NdJSONRequest;
+use Sigmie\Sigmie;
 use Sigmie\Testing\TestCase;
 
 class HttpTest extends TestCase
 {
+    /**
+     * @test
+     */
+    public function create_for_cloud_returns_sigmie_instance(): void
+    {
+        $cloudId = 'test:'.base64_encode('us-east-1.aws.found.io$esid$kibanaid');
+
+        $sigmie = Sigmie::createForCloud($cloudId, 'my-api-key');
+
+        $this->assertInstanceOf(Sigmie::class, $sigmie);
+    }
+
     /**
      * @test
      */

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -30,6 +30,19 @@ class HttpTest extends TestCase
     /**
      * @test
      */
+    public function create_for_serverless_returns_sigmie_instance(): void
+    {
+        $sigmie = Sigmie::createForServerless(
+            'https://my-project.es.us-east-1.aws.elastic.cloud',
+            'my-api-key'
+        );
+
+        $this->assertInstanceOf(Sigmie::class, $sigmie);
+    }
+
+    /**
+     * @test
+     */
     public function response(): void
     {
         $successfulResponse = JSONResponse::fromPsrResponse(new PsrResponse(200, ['content-type' => 'application/json'], '{"foo":"bar"}'));


### PR DESCRIPTION
## Summary

- Adds `Sigmie::createForCloud(string $cloudId, string $apiKey): static` factory method
- Delegates host resolution to `TransportBuilder::setCloudId()` — no manual URL decoding needed
- Sets the `Authorization: ApiKey …` header on the Guzzle client

## Usage

```php
$sigmie = Sigmie::createForCloud(
    cloudId: 'my-deployment:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQ...',
    apiKey:  'VnVhQ2ZHY0JDZGJrUW0tZTVhT3g6...'
);
```

Both values are copied directly from the Elastic Cloud console.

## Test plan

- [x] `create_for_cloud_returns_sigmie_instance` in `HttpTest` — verifies the factory builds a `Sigmie` instance from a valid cloud ID without making any HTTP requests

Made with [Cursor](https://cursor.com)