### PR TITLE
feat: multisearch lazy PIT iteration and RawQuery

### DIFF
--- a/docs/document.md
+++ b/docs/document.md
@@ -211,21 +211,25 @@ if ($movies instanceof AliveCollection) {
 
 ### Iterating Through Documents
 
+`each()` streams all documents from the collection without loading them all into memory. Sigmie fetches them in pages using Point-in-Time (PIT) and `search_after`, so the result is consistent even if writes happen during iteration.
+
 ```php
-$movies = $sigmie->collect('movies', refresh: true);
+$movies = $sigmie->collect('movies');
 
-// Add some documents first
-$movies->merge([
-    new Document(['title' => 'Movie 1']),
-    new Document(['title' => 'Movie 2']),
-    new Document(['title' => 'Movie 3'])
-]);
-
-// Lazy iteration (memory efficient for large collections)
-$movies->each(function (Document $document) {
+$movies->each(function (Document $document): void {
     echo $document['title'] . "\n";
 });
 ```
+
+By default, documents are fetched 500 at a time. Use `chunk()` to change the page size:
+
+```php
+$movies->chunk(100)->each(function (Document $document): void {
+    processDocument($document);
+});
+```
+
+To iterate over a **filtered** subset instead of the entire collection, use `NewSearch::each()` or `NewSearch::lazy()`. See the [Search documentation](search.md#iterating-over-all-matching-hits) for details.
 
 ### Converting to Array
 
@@ -356,17 +360,16 @@ foreach ($manyDocuments as $doc) {
 
 ### Memory Management
 
-For large collections, use lazy iteration:
+For large collections, use `each()` instead of loading everything at once:
 
 ```php
-// Memory efficient for large datasets
-$movies->each(function (Document $doc) {
-    // Process each document
+// Memory efficient: fetches documents page by page
+$movies->each(function (Document $doc): void {
     processDocument($doc);
 });
 
-// Memory intensive for large datasets
-$allDocs = $movies->toArray();  // Loads everything into memory
+// Memory intensive: loads all documents at once
+$allDocs = $movies->toArray();
 ```
 
 ### Index Optimization

--- a/docs/search.md
+++ b/docs/search.md
@@ -408,6 +408,98 @@ $hits = $response->hits();
 $total = $response->total();
 ```
 
+## Iterating Over All Matching Hits
+
+Pagination works well for UI results, but some tasks — CSV exports, bulk re-processing, data migrations — need every document that matches a query. `each()` and `lazy()` stream all matching hits without holding the full result set in memory.
+
+Both methods reuse the exact query you already have: filters, query strings, field scoping, and minimum score all apply. Elasticsearch handles pagination internally using Point-in-Time (PIT) and `search_after`, so the results are consistent even if new documents arrive while you iterate.
+
+### Iterating with a Callback
+
+`each()` calls a closure for every matching `Hit`:
+
+```php
+$sigmie->newSearch('orders')
+    ->properties($properties)
+    ->filters('status:completed')
+    ->each(function (Hit $hit) use ($csv) {
+        $csv->writeRow($hit->_source);
+    });
+```
+
+Each `Hit` carries `_id`, `_source`, and `_score`:
+
+```php
+$sigmie->newSearch('products')
+    ->properties($properties)
+    ->filters('in_stock:true')
+    ->each(function (Hit $hit): void {
+        echo $hit->_id;            // document ID
+        echo $hit->_source['name']; // field value
+        echo $hit->_score;         // relevance score
+    });
+```
+
+### Iterating with a Generator
+
+`lazy()` returns a `Generator` you can drive yourself. This is useful when you need to pass an iterable to another function or process hits in batches using regular PHP:
+
+```php
+$generator = $sigmie->newSearch('orders')
+    ->properties($properties)
+    ->filters('status:completed')
+    ->lazy();
+
+foreach ($generator as $hit) {
+    processHit($hit);
+}
+```
+
+### Controlling Page Size
+
+Both `each()` and `lazy()` fetch hits in pages. The default page size is 500. Use `chunk()` to change it:
+
+```php
+$sigmie->newSearch('products')
+    ->properties($properties)
+    ->chunk(100)
+    ->each(function (Hit $hit): void {
+        // called for every product, fetched 100 at a time
+    });
+```
+
+A smaller chunk size reduces memory per request; a larger one reduces the number of round-trips to Elasticsearch. Tune it based on document size and your available memory.
+
+### Streaming hits from a multi-search
+
+`newMultiSearch()` registers several queries. A single `_msearch` call returns only the first page per query. To stream **all** matching hits across those queries, call `lazy()` or `each()` on the multi-search instance. Each registered `NewSearch`, `NewQuery`, or `raw()` body runs its own PIT iteration; the multi-search yields hits in registration order (first query fully, then the next).
+
+```php
+use Sigmie\Document\Hit;
+
+$multi = $sigmie->newMultiSearch();
+
+$multi->newSearch('orders')
+    ->properties($orderProperties)
+    ->filters('status:pending')
+    ->chunk(200);
+
+$multi->newQuery('products')
+    ->matchAll();
+
+$multi->raw('orders', [
+    'query' => ['term' => ['status' => 'pending']]],
+])->chunk(200);
+
+foreach ($multi->lazy() as $hit) {
+    exportRow($hit);
+}
+```
+
+Set `chunk()` on each query before the next registration — the multi-search object does not expose its own `chunk()`; page size is per query. `raw()` returns a `RawQuery` instance; call `chunk()` on that return value before you register the next slot if you want a non-default page size for that raw body.
+
+> **Note:** `each()` and `lazy()` ignore `from()`, `size()`, `page()`, and `highlighting()` — these are pagination and display concerns that do not apply to full iteration.
+
 ## Promises
 For asynchronous operations, you can get a Promise instead of executing the search immediately:
 

--- a/src/Base/APIs/Search.php
+++ b/src/Base/APIs/Search.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Sigmie\Base\APIs;
 
 use GuzzleHttp\Psr7\Uri;
+use Sigmie\Base\Contracts\ElasticsearchResponse;
+use Sigmie\Base\Http\PointInTimeRequests;
 use Sigmie\Base\Http\Requests\Search as SearchRequest;
 use Sigmie\Base\Http\Responses\Search as SearchResponse;
 
@@ -12,30 +14,36 @@ trait Search
 {
     use API;
 
-    protected function searchAPICall(string $index, array $query, ?string $scroll = null): SearchResponse
+    protected function searchAPICall(string $index, array $query): SearchResponse
     {
-        $esRequest = $this->searchRequest($index, $query, $scroll);
+        $esRequest = $this->searchRequest($index, $query);
 
         return $this->elasticsearchCall($esRequest);
     }
 
-    protected function scrollAPICall(string $scrollId, string $scroll): SearchResponse
+    protected function pitSearchAPICall(array $body): ElasticsearchResponse
     {
-        $uri = new Uri('/_search/scroll');
-
-        return $this->elasticsearchCall(new SearchRequest('POST', $uri, [
-            'scroll' => $scroll,
-            'scroll_id' => $scrollId,
-        ]));
+        return $this->pitRequests()->search($body);
     }
 
-    protected function searchRequest(string $index, array $query, ?string $scroll = null): SearchRequest
+    protected function openPointInTimeAPICall(string $index, string $keepAlive = '1m'): ElasticsearchResponse
+    {
+        return $this->pitRequests()->open($index, $keepAlive);
+    }
+
+    protected function closePointInTimeAPICall(string $pitId): ElasticsearchResponse
+    {
+        return $this->pitRequests()->close($pitId);
+    }
+
+    protected function pitRequests(): PointInTimeRequests
+    {
+        return new PointInTimeRequests($this->elasticsearchConnection);
+    }
+
+    protected function searchRequest(string $index, array $query): SearchRequest
     {
         $uri = new Uri(sprintf('/%s/_search', $index));
-
-        if ($scroll) {
-            $uri = $uri->withQuery('scroll='.$scroll);
-        }
 
         return new SearchRequest('POST', $uri, $query);
     }

--- a/src/Base/Http/PointInTimeRequests.php
+++ b/src/Base/Http/PointInTimeRequests.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\Base\Http;
+
+use GuzzleHttp\Psr7\Uri;
+use Sigmie\Base\Contracts\ElasticsearchConnection;
+use Sigmie\Base\Contracts\ElasticsearchResponse;
+use Sigmie\Base\Http\Requests\Search as SearchRequest;
+use Sigmie\Enums\SearchEngineType;
+
+final class PointInTimeRequests
+{
+    public function __construct(
+        private ElasticsearchConnection $connection,
+    ) {}
+
+    public function open(string $index, string $keepAlive = '1m'): ElasticsearchResponse
+    {
+        if ($this->connection->driver()->engine() === SearchEngineType::OpenSearch) {
+            $uri = new Uri(sprintf('/%s/_search/point_in_time', $index));
+
+            return $this->call(new SearchRequest(
+                'POST',
+                $uri->withQuery('keep_alive='.rawurlencode($keepAlive)),
+                [],
+            ));
+        }
+
+        $uri = new Uri(sprintf('/%s/_pit', $index));
+
+        return $this->call(new SearchRequest(
+            'POST',
+            $uri->withQuery('keep_alive='.rawurlencode($keepAlive)),
+            [],
+        ));
+    }
+
+    public function close(string $pitId): ElasticsearchResponse
+    {
+        if ($this->connection->driver()->engine() === SearchEngineType::OpenSearch) {
+            $uri = new Uri('/_search/point_in_time');
+
+            return $this->call(new SearchRequest('DELETE', $uri, [
+                'pit_id' => [$pitId],
+            ]));
+        }
+
+        $uri = new Uri('/_pit');
+
+        return $this->call(new SearchRequest('DELETE', $uri, [
+            'id' => $pitId,
+        ]));
+    }
+
+    /**
+     * @param  array<string, mixed>  $body
+     */
+    public function search(array $body): ElasticsearchResponse
+    {
+        $uri = new Uri('/_search');
+
+        return $this->call(new SearchRequest('POST', $uri, $body));
+    }
+
+    private function call(SearchRequest $request): ElasticsearchResponse
+    {
+        return ($this->connection)($request);
+    }
+}

--- a/src/Document/LazyEach.php
+++ b/src/Document/LazyEach.php
@@ -8,6 +8,8 @@ use Closure;
 use Iterator;
 use Sigmie\Base\APIs\Count;
 use Sigmie\Document\Actions as DocumentActions;
+use Sigmie\Enums\SearchEngineType;
+use Sigmie\Search\PointInTimeIterator;
 
 trait LazyEach
 {
@@ -34,55 +36,50 @@ trait LazyEach
 
     protected function indexGenerator(): Iterator
     {
-        $page = 1;
-        $total = (int) $this->countAPICall($this->name)->json('count');
+        $isOpenSearch = $this->elasticsearchConnection->driver()->engine() === SearchEngineType::OpenSearch;
 
-        // Initial scroll request
-        $body = [
+        $sort = $isOpenSearch ? [['_id' => 'asc']] : [['_shard_doc' => 'asc']];
+
+        $baseBody = [
             'size' => $this->chunk,
-            // Return documents in the order they are stored internally in the index, per shard.
-            // It is the most efficient sort, especially for large scans or scrolls.
-            'sort' => [['_doc' => 'asc']],
+            'sort' => $sort,
             'query' => ['match_all' => (object) []],
         ];
 
         if ($this->only || $this->except) {
-
-            $body['_source'] = [];
+            $baseBody['_source'] = [];
 
             if ($this->only) {
-                $body['_source']['includes'] = $this->only;
+                $baseBody['_source']['includes'] = $this->only;
             }
 
             if ($this->except) {
-                $body['_source']['excludes'] = $this->except;
+                $baseBody['_source']['excludes'] = $this->except;
             }
         }
 
-        $response = $this->searchAPICall(index: $this->name, query: $body, scroll: '1m');
+        $keepAlive = '1m';
 
-        $scrollId = $response->json('_scroll_id');
+        $open = $this->openPointInTimeAPICall($this->name, $keepAlive);
+        $pitId = PointInTimeIterator::pitIdFromOpenResponse($open, $isOpenSearch);
 
-        foreach ($response->json('hits')['hits'] as $data) {
-            yield $data['_id'] => new Document($data['_source'], $data['_id']);
-        }
-
-        while ($this->chunk * $page < $total) {
-            $page++;
-
-            yield from $this->pageGenerator($scrollId);
-        }
-    }
-
-    protected function pageGenerator(string $scrollId): Iterator
-    {
-        // Continue scrolling with scroll_id
-        $response = $this->scrollAPICall($scrollId, '1m');
-
-        $values = $response->json('hits')['hits'];
-
-        foreach ($values as $data) {
-            yield $data['_id'] => new Document($data['_source'], $data['_id']);
+        foreach (PointInTimeIterator::iterate(
+            $pitId,
+            $keepAlive,
+            $baseBody,
+            fn (array $body) => $this->pitSearchAPICall($body),
+            function (string $id): void {
+                $this->closePointInTimeAPICall($id);
+            },
+            fn (array $data): Hit => new Hit(
+                $data['_source'] ?? [],
+                $data['_id'],
+                isset($data['_score']) ? (float) $data['_score'] : null,
+                $data['_index'] ?? null,
+                $data['sort'] ?? null,
+            ),
+        ) as $hit) {
+            yield $hit->_id => $hit;
         }
     }
 }

--- a/src/Query/NewQuery.php
+++ b/src/Query/NewQuery.php
@@ -7,6 +7,7 @@ namespace Sigmie\Query;
 use Closure;
 use Generator;
 use Sigmie\Base\Contracts\ElasticsearchConnection;
+use Sigmie\Base\Contracts\ElasticsearchResponse;
 use Sigmie\Base\Http\PointInTimeRequests;
 use Sigmie\Document\Hit;
 use Sigmie\Enums\SearchEngineType;
@@ -309,7 +310,7 @@ class NewQuery implements LazyIterableQuery, MultiSearchable, Queries
             $pitId,
             $keepAlive,
             $body,
-            fn (array $requestBody) => $pit->search($requestBody),
+            fn (array $requestBody): ElasticsearchResponse => $pit->search($requestBody),
             function (string $id) use ($pit): void {
                 $pit->close($id);
             },

--- a/src/Query/NewQuery.php
+++ b/src/Query/NewQuery.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Sigmie\Query;
 
+use Closure;
+use Generator;
 use Sigmie\Base\Contracts\ElasticsearchConnection;
+use Sigmie\Base\Http\PointInTimeRequests;
+use Sigmie\Document\Hit;
+use Sigmie\Enums\SearchEngineType;
 use Sigmie\Mappings\NewProperties;
 use Sigmie\Mappings\Properties;
 use Sigmie\Parse\FilterParser;
@@ -23,17 +28,21 @@ use Sigmie\Query\Queries\Term\Terms;
 use Sigmie\Query\Queries\Term\Wildcard;
 use Sigmie\Query\Queries\Text\Match_;
 use Sigmie\Query\Queries\Text\MultiMatch;
+use Sigmie\Search\Contracts\LazyIterableQuery;
 use Sigmie\Search\Contracts\MultiSearchable;
+use Sigmie\Search\PointInTimeIterator;
 
 use function Sigmie\Functions\random_name;
 
-class NewQuery implements MultiSearchable, Queries
+class NewQuery implements LazyIterableQuery, MultiSearchable, Queries
 {
     protected Search $search;
 
     protected Properties $properties;
 
     protected string $searchName = '';
+
+    protected int $pitIterationChunkSize = 500;
 
     public function __construct(
         protected ElasticsearchConnection $httpConnection,
@@ -245,5 +254,72 @@ class NewQuery implements MultiSearchable, Queries
         }
 
         return random_name('qr');
+    }
+
+    public function chunk(int $size = 500): static
+    {
+        $this->pitIterationChunkSize = $size;
+
+        return $this;
+    }
+
+    /**
+     * @return Generator<int, Hit>
+     */
+    public function lazy(): Generator
+    {
+        yield from $this->iterateHits();
+    }
+
+    public function each(Closure $fn): void
+    {
+        foreach ($this->iterateHits() as $hit) {
+            $fn($hit);
+        }
+    }
+
+    /**
+     * @return Generator<int, Hit>
+     */
+    protected function iterateHits(): Generator
+    {
+        $pit = new PointInTimeRequests($this->httpConnection);
+        $isOpenSearch = $this->httpConnection->driver()->engine() === SearchEngineType::OpenSearch;
+
+        $body = $this->search->toRaw();
+
+        unset(
+            $body['from'],
+            $body['size'],
+            $body['aggs'],
+            $body['highlight'],
+            $body['suggest'],
+            $body['track_total_hits'],
+            $body['sort'],
+        );
+
+        $body['size'] = $this->pitIterationChunkSize;
+        $body['sort'] = $isOpenSearch ? [['_id' => 'asc']] : [['_shard_doc' => 'asc']];
+
+        $keepAlive = '1m';
+        $open = $pit->open($this->search->index, $keepAlive);
+        $pitId = PointInTimeIterator::pitIdFromOpenResponse($open, $isOpenSearch);
+
+        yield from PointInTimeIterator::iterate(
+            $pitId,
+            $keepAlive,
+            $body,
+            fn (array $requestBody) => $pit->search($requestBody),
+            function (string $id) use ($pit): void {
+                $pit->close($id);
+            },
+            fn (array $data): Hit => new Hit(
+                $data['_source'] ?? [],
+                $data['_id'],
+                isset($data['_score']) ? (float) $data['_score'] : null,
+                $data['_index'] ?? null,
+                $data['sort'] ?? null,
+            ),
+        );
     }
 }

--- a/src/Search/Contracts/LazyIterableQuery.php
+++ b/src/Search/Contracts/LazyIterableQuery.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\Search\Contracts;
+
+use Closure;
+use Generator;
+use Sigmie\Document\Hit;
+
+interface LazyIterableQuery
+{
+    public function chunk(int $size): static;
+
+    /**
+     * @return Generator<int, Hit>
+     */
+    public function lazy(): Generator;
+
+    public function each(Closure $fn): void;
+}

--- a/src/Search/NewMultiSearch.php
+++ b/src/Search/NewMultiSearch.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace Sigmie\Search;
 
+use Closure;
+use Generator;
 use Sigmie\Base\APIs\MSearch;
 use Sigmie\Base\Contracts\ElasticsearchConnection;
 use Sigmie\Base\ElasticsearchException;
+use Sigmie\Document\Hit;
 use Sigmie\Query\NewQuery;
+use Sigmie\Search\Contracts\LazyIterableQuery;
 use Sigmie\Search\Contracts\MultiSearchable;
 use Sigmie\Shared\UsesApis;
 
@@ -18,7 +22,7 @@ class NewMultiSearch
     use MSearch;
     use UsesApis;
 
-    /** @var array Ordered list of all queries (MultiSearchable objects and raw arrays) */
+    /** @var list<MultiSearchable> */
     protected array $queries = [];
 
     /** @var array Names associated with each query (by index) */
@@ -62,33 +66,24 @@ class NewMultiSearch
         return $query;
     }
 
-    public function raw(string $index, array $query, ?string $name = null): static
+    public function raw(string $index, array $query, ?string $name = null): RawQuery
     {
-        $this->queries[] = [
-            ['index' => $index],
-            $query,
-        ];
+        $raw = new RawQuery($this->elasticsearchConnection, $index, $query);
+        $this->queries[] = $raw;
         $this->names[count($this->queries) - 1] = $name ?? random_name('srch');
 
-        return $this;
+        return $raw;
     }
 
     public function get(): array
     {
         $body = [];
 
-        // Build body in the order queries were added
         foreach ($this->queries as $query) {
-            if ($query instanceof MultiSearchable) {
-                $body = [
-                    ...$body,
-                    ...$query->toMultiSearch(),
-                ];
-            } else {
-                // Raw query (array format: [header, body])
-                $body[] = $query[0]; // header
-                $body[] = $query[1]; // body
-            }
+            $body = [
+                ...$body,
+                ...$query->toMultiSearch(),
+            ];
         }
 
         $response = $this->msearchAPICall($body);
@@ -103,21 +98,13 @@ class NewMultiSearch
         $results = [];
         $responseIndex = 0;
 
-        // Process responses in the same order
         foreach ($this->queries as $query) {
-            if ($query instanceof MultiSearchable) {
-                $searchResponses = array_slice($responses, $responseIndex, $query->multisearchResCount());
+            $searchResponses = array_slice($responses, $responseIndex, $query->multisearchResCount());
 
-                // Pass HTTP code as the last argument
-                $result = $query->formatResponses(...$searchResponses, httpCode: $this->responseCode);
+            $result = $query->formatResponses(...$searchResponses, httpCode: $this->responseCode);
 
-                $results[] = $result;
-                $responseIndex += $query->multisearchResCount();
-            } else {
-                // Raw query
-                $results[] = $responses[$responseIndex] ?? [];
-                $responseIndex += 1;
-            }
+            $results[] = $result;
+            $responseIndex += $query->multisearchResCount();
         }
 
         return $results;
@@ -165,5 +152,34 @@ class NewMultiSearch
     public function responseCode(): int
     {
         return $this->responseCode;
+    }
+
+    /**
+     * @return Generator<int, Hit>
+     */
+    public function lazy(): Generator
+    {
+        foreach ($this->queries as $query) {
+            if (! $query instanceof LazyIterableQuery) {
+                continue;
+            }
+
+            foreach ($query->lazy() as $hit) {
+                yield $hit;
+            }
+        }
+    }
+
+    public function each(Closure $fn): void
+    {
+        foreach ($this->queries as $query) {
+            if (! $query instanceof LazyIterableQuery) {
+                continue;
+            }
+
+            foreach ($query->lazy() as $hit) {
+                $fn($hit);
+            }
+        }
     }
 }

--- a/src/Search/NewSearch.php
+++ b/src/Search/NewSearch.php
@@ -8,8 +8,10 @@ use Closure;
 use Generator;
 use Http\Promise\Promise;
 use Sigmie\AI\Contracts\EmbeddingsApi;
+use Sigmie\Base\Contracts\ElasticsearchResponse;
 use Sigmie\Base\Http\ElasticsearchConnection;
 use Sigmie\Base\Http\PointInTimeRequests;
+use Sigmie\Document\Hit;
 use Sigmie\Enums\SearchEngineType;
 use Sigmie\Mappings\NewProperties;
 use Sigmie\Mappings\Properties;
@@ -28,11 +30,10 @@ use Sigmie\Query\Contracts\FuzzyQuery;
 use Sigmie\Query\Contracts\QueryClause as Query;
 use Sigmie\Query\FunctionScore;
 use Sigmie\Query\Queries\Compound\Boolean;
-use Sigmie\Query\Queries\MatchAll;
 // use Sigmie\Query\Queries\Query;
+use Sigmie\Query\Queries\MatchAll;
 use Sigmie\Query\Queries\MatchNone;
 use Sigmie\Query\Queries\Text\Nested;
-use Sigmie\Document\Hit;
 use Sigmie\Query\Search;
 use Sigmie\Query\Suggest;
 use Sigmie\Search\Contracts\LazyIterableQuery;
@@ -1025,7 +1026,7 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
             $pitId,
             $keepAlive,
             $body,
-            fn (array $requestBody) => $pit->search($requestBody),
+            fn (array $requestBody): ElasticsearchResponse => $pit->search($requestBody),
             function (string $id) use ($pit): void {
                 $pit->close($id);
             },
@@ -1077,11 +1078,7 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
             return true;
         }
 
-        if (is_array($only) && (isset($only['_score']) || isset($only['_doc']))) {
-            return true;
-        }
-
-        return false;
+        return is_array($only) && (isset($only['_score']) || isset($only['_doc']));
     }
 
     /**

--- a/src/Search/NewSearch.php
+++ b/src/Search/NewSearch.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Sigmie\Search;
 
+use Closure;
+use Generator;
 use Http\Promise\Promise;
 use Sigmie\AI\Contracts\EmbeddingsApi;
 use Sigmie\Base\Http\ElasticsearchConnection;
+use Sigmie\Base\Http\PointInTimeRequests;
 use Sigmie\Enums\SearchEngineType;
 use Sigmie\Mappings\NewProperties;
 use Sigmie\Mappings\Properties;
@@ -29,8 +32,10 @@ use Sigmie\Query\Queries\MatchAll;
 // use Sigmie\Query\Queries\Query;
 use Sigmie\Query\Queries\MatchNone;
 use Sigmie\Query\Queries\Text\Nested;
+use Sigmie\Document\Hit;
 use Sigmie\Query\Search;
 use Sigmie\Query\Suggest;
+use Sigmie\Search\Contracts\LazyIterableQuery;
 use Sigmie\Search\Contracts\MultiSearchable;
 use Sigmie\Search\Contracts\ResponseFormater;
 use Sigmie\Search\Contracts\SearchQueryBuilder as SearchQueryBuilderInterface;
@@ -38,7 +43,7 @@ use Sigmie\Search\Formatters\SigmieSearchResponse;
 use Sigmie\Shared\Collection;
 use Sigmie\Shared\UsesApis;
 
-class NewSearch extends AbstractSearchBuilder implements MultiSearchable, SearchQueryBuilderInterface
+class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, MultiSearchable, SearchQueryBuilderInterface
 {
     use UsesApis;
 
@@ -69,6 +74,8 @@ class NewSearch extends AbstractSearchBuilder implements MultiSearchable, Search
     public readonly SortParser $sortParser;
 
     protected array $vectorPools = [];
+
+    protected int $pitIterationChunkSize = 500;
 
     public function __construct(
         ElasticsearchConnection $elasticsearchConnection
@@ -963,6 +970,134 @@ class NewSearch extends AbstractSearchBuilder implements MultiSearchable, Search
     public function hits()
     {
         return $this->get()->hits();
+    }
+
+    public function chunk(int $size = 500): static
+    {
+        $this->pitIterationChunkSize = $size;
+
+        return $this;
+    }
+
+    /**
+     * @return Generator<int, Hit>
+     */
+    public function lazy(): Generator
+    {
+        yield from $this->iterateHits();
+    }
+
+    public function each(Closure $fn): void
+    {
+        foreach ($this->iterateHits() as $hit) {
+            $fn($hit);
+        }
+    }
+
+    /**
+     * @return Generator<int, Hit>
+     */
+    protected function iterateHits(): Generator
+    {
+        $pit = new PointInTimeRequests($this->elasticsearchConnection);
+        $isOpenSearch = $this->elasticsearchConnection->driver()->engine() === SearchEngineType::OpenSearch;
+
+        $body = $this->makeSearch()->toRaw();
+
+        unset(
+            $body['from'],
+            $body['size'],
+            $body['aggs'],
+            $body['highlight'],
+            $body['suggest'],
+            $body['track_total_hits'],
+            $body['sort'],
+        );
+
+        $body['size'] = $this->pitIterationChunkSize;
+        $body['sort'] = $this->stableSortForPitIteration();
+
+        $keepAlive = '1m';
+        $open = $pit->open($this->index, $keepAlive);
+        $pitId = PointInTimeIterator::pitIdFromOpenResponse($open, $isOpenSearch);
+
+        yield from PointInTimeIterator::iterate(
+            $pitId,
+            $keepAlive,
+            $body,
+            fn (array $requestBody) => $pit->search($requestBody),
+            function (string $id) use ($pit): void {
+                $pit->close($id);
+            },
+            fn (array $data): Hit => new Hit(
+                $data['_source'] ?? [],
+                $data['_id'],
+                isset($data['_score']) ? (float) $data['_score'] : null,
+                $data['_index'] ?? null,
+                $data['sort'] ?? null,
+            ),
+        );
+    }
+
+    /**
+     * @return list<string|array<string, mixed>>
+     */
+    private function stableSortForPitIteration(): array
+    {
+        $isOpenSearch = $this->elasticsearchConnection->driver()->engine() === SearchEngineType::OpenSearch;
+        $tiebreaker = $isOpenSearch ? [['_id' => 'asc']] : [['_shard_doc' => 'asc']];
+
+        if ($this->sortUsesOnlyScoreOrDoc($this->sort)) {
+            return $tiebreaker;
+        }
+
+        return $this->appendPitTiebreakerUnlessPresent($this->sort, $tiebreaker);
+    }
+
+    /**
+     * @param  list<string|array<string, mixed>>  $sort
+     */
+    private function sortUsesOnlyScoreOrDoc(array $sort): bool
+    {
+        if ($sort === []) {
+            return true;
+        }
+
+        if ($sort === ['_score'] || $sort === ['_doc']) {
+            return true;
+        }
+
+        if (count($sort) !== 1) {
+            return false;
+        }
+
+        $only = $sort[0];
+
+        if ($only === '_score' || $only === '_doc') {
+            return true;
+        }
+
+        if (is_array($only) && (isset($only['_score']) || isset($only['_doc']))) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<string|array<string, mixed>>  $sort
+     * @param  list<array<string, string>>  $tiebreaker
+     * @return list<string|array<string, mixed>>
+     */
+    private function appendPitTiebreakerUnlessPresent(array $sort, array $tiebreaker): array
+    {
+        $last = $sort[array_key_last($sort)];
+
+        if (is_array($last) && (isset($last['_shard_doc']) || isset($last['_id']))) {
+            return $sort;
+        }
+
+        return array_merge($sort, $tiebreaker);
     }
 
     public function setVectorPool(VectorPool|array $pool, ?string $apiName = null): static

--- a/src/Search/PointInTimeIterator.php
+++ b/src/Search/PointInTimeIterator.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\Search;
+
+use Generator;
+use Sigmie\Base\Contracts\ElasticsearchResponse;
+
+final class PointInTimeIterator
+{
+    public static function pitIdFromOpenResponse(ElasticsearchResponse $response, bool $isOpenSearch): string
+    {
+        $id = $isOpenSearch ? $response->json('pit_id') : $response->json('id');
+
+        return (string) $id;
+    }
+
+    public static function updatedPitIdFromSearchResponse(ElasticsearchResponse $response): ?string
+    {
+        $pitId = $response->json('pit_id');
+        if (is_string($pitId) && $pitId !== '') {
+            return $pitId;
+        }
+
+        $nested = $response->json('pit.id');
+        if (is_string($nested) && $nested !== '') {
+            return $nested;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  callable(array<string, mixed>): ElasticsearchResponse  $pitSearch
+     * @param  callable(string): void  $closePit
+     * @param  callable(array<string, mixed>): mixed  $mapHit
+     */
+    public static function iterate(
+        string $initialPitId,
+        string $keepAlive,
+        array $baseBody,
+        callable $pitSearch,
+        callable $closePit,
+        callable $mapHit,
+    ): Generator {
+        $pitId = $initialPitId;
+
+        try {
+            $searchAfter = null;
+
+            while (true) {
+                $body = array_merge($baseBody, [
+                    'pit' => [
+                        'id' => $pitId,
+                        'keep_alive' => $keepAlive,
+                    ],
+                ]);
+
+                if ($searchAfter !== null) {
+                    $body['search_after'] = $searchAfter;
+                }
+
+                $response = $pitSearch($body);
+
+                $updated = self::updatedPitIdFromSearchResponse($response);
+                if ($updated !== null) {
+                    $pitId = $updated;
+                }
+
+                /** @var list<array<string, mixed>> $hits */
+                $hits = $response->json('hits.hits') ?? [];
+
+                if ($hits === []) {
+                    break;
+                }
+
+                $lastSort = null;
+
+                foreach ($hits as $data) {
+                    yield $mapHit($data);
+
+                    $lastSort = $data['sort'] ?? null;
+                }
+
+                if ($lastSort === null || $lastSort === []) {
+                    break;
+                }
+
+                $searchAfter = $lastSort;
+            }
+        } finally {
+            $closePit($pitId);
+        }
+    }
+}

--- a/src/Search/RawQuery.php
+++ b/src/Search/RawQuery.php
@@ -7,6 +7,7 @@ namespace Sigmie\Search;
 use Closure;
 use Generator;
 use Sigmie\Base\Contracts\ElasticsearchConnection;
+use Sigmie\Base\Contracts\ElasticsearchResponse;
 use Sigmie\Base\Http\PointInTimeRequests;
 use Sigmie\Document\Hit;
 use Sigmie\Enums\SearchEngineType;
@@ -15,12 +16,12 @@ use Sigmie\Search\Contracts\MultiSearchable;
 
 final class RawQuery implements LazyIterableQuery, MultiSearchable
 {
-    protected int $pitIterationChunkSize = 500;
+    private int $pitIterationChunkSize = 500;
 
     public function __construct(
-        protected ElasticsearchConnection $httpConnection,
-        protected string $index,
-        protected array $body,
+        private ElasticsearchConnection $httpConnection,
+        private string $index,
+        private array $body,
     ) {}
 
     public function toMultiSearch(): array
@@ -66,7 +67,7 @@ final class RawQuery implements LazyIterableQuery, MultiSearchable
     /**
      * @return Generator<int, Hit>
      */
-    protected function iterateHits(): Generator
+    private function iterateHits(): Generator
     {
         $pit = new PointInTimeRequests($this->httpConnection);
         $isOpenSearch = $this->httpConnection->driver()->engine() === SearchEngineType::OpenSearch;
@@ -95,7 +96,7 @@ final class RawQuery implements LazyIterableQuery, MultiSearchable
             $pitId,
             $keepAlive,
             $body,
-            fn (array $requestBody) => $pit->search($requestBody),
+            fn (array $requestBody): ElasticsearchResponse => $pit->search($requestBody),
             function (string $id) use ($pit): void {
                 $pit->close($id);
             },

--- a/src/Search/RawQuery.php
+++ b/src/Search/RawQuery.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\Search;
+
+use Closure;
+use Generator;
+use Sigmie\Base\Contracts\ElasticsearchConnection;
+use Sigmie\Base\Http\PointInTimeRequests;
+use Sigmie\Document\Hit;
+use Sigmie\Enums\SearchEngineType;
+use Sigmie\Search\Contracts\LazyIterableQuery;
+use Sigmie\Search\Contracts\MultiSearchable;
+
+final class RawQuery implements LazyIterableQuery, MultiSearchable
+{
+    protected int $pitIterationChunkSize = 500;
+
+    public function __construct(
+        protected ElasticsearchConnection $httpConnection,
+        protected string $index,
+        protected array $body,
+    ) {}
+
+    public function toMultiSearch(): array
+    {
+        return [
+            ['index' => $this->index],
+            $this->body,
+        ];
+    }
+
+    public function multisearchResCount(): int
+    {
+        return 1;
+    }
+
+    public function formatResponses(...$responses): mixed
+    {
+        return $responses[0] ?? [];
+    }
+
+    public function chunk(int $size = 500): static
+    {
+        $this->pitIterationChunkSize = $size;
+
+        return $this;
+    }
+
+    /**
+     * @return Generator<int, Hit>
+     */
+    public function lazy(): Generator
+    {
+        yield from $this->iterateHits();
+    }
+
+    public function each(Closure $fn): void
+    {
+        foreach ($this->iterateHits() as $hit) {
+            $fn($hit);
+        }
+    }
+
+    /**
+     * @return Generator<int, Hit>
+     */
+    protected function iterateHits(): Generator
+    {
+        $pit = new PointInTimeRequests($this->httpConnection);
+        $isOpenSearch = $this->httpConnection->driver()->engine() === SearchEngineType::OpenSearch;
+
+        $body = $this->body;
+
+        unset(
+            $body['from'],
+            $body['size'],
+            $body['aggs'],
+            $body['highlight'],
+            $body['suggest'],
+            $body['track_total_hits'],
+            $body['sort'],
+            $body['post_filter'],
+        );
+
+        $body['size'] = $this->pitIterationChunkSize;
+        $body['sort'] = $isOpenSearch ? [['_id' => 'asc']] : [['_shard_doc' => 'asc']];
+
+        $keepAlive = '1m';
+        $open = $pit->open($this->index, $keepAlive);
+        $pitId = PointInTimeIterator::pitIdFromOpenResponse($open, $isOpenSearch);
+
+        yield from PointInTimeIterator::iterate(
+            $pitId,
+            $keepAlive,
+            $body,
+            fn (array $requestBody) => $pit->search($requestBody),
+            function (string $id) use ($pit): void {
+                $pit->close($id);
+            },
+            fn (array $data): Hit => new Hit(
+                $data['_source'] ?? [],
+                $data['_id'],
+                isset($data['_score']) ? (float) $data['_score'] : null,
+                $data['_index'] ?? null,
+                $data['sort'] ?? null,
+            ),
+        );
+    }
+}

--- a/src/Traits/SigmieIndexTrait.php
+++ b/src/Traits/SigmieIndexTrait.php
@@ -14,6 +14,7 @@ use Sigmie\Mappings\NewProperties;
 use Sigmie\Query\NewQuery;
 use Sigmie\Search\NewMultiSearch;
 use Sigmie\Search\NewSearch;
+use Sigmie\Search\RawQuery;
 use Sigmie\Sigmie;
 
 trait SigmieIndexTrait
@@ -147,7 +148,7 @@ trait SigmieIndexTrait
                 return $this->multiSearch->newQuery($index);
             }
 
-            public function raw(string $indexName, array $query): NewMultiSearch
+            public function raw(string $indexName, array $query): RawQuery
             {
                 return $this->multiSearch->raw($indexName, $query);
             }

--- a/tests/MultiSearchTest.php
+++ b/tests/MultiSearchTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Sigmie\Tests;
 
+use Generator;
 use Sigmie\Document\Document;
+use Sigmie\Document\Hit;
 use Sigmie\Mappings\NewProperties;
 use Sigmie\Search\Formatters\SigmieSearchResponse;
 use Sigmie\Testing\TestCase;
@@ -72,5 +74,180 @@ class MultiSearchTest extends TestCase
         $this->assertEquals('Goofy', $search2Hit['name']);
         $this->assertEquals(2, $newQueryRes['hits']['total']['value']);
         $this->assertEquals(0, $rawRes['hits']['total']['value']);
+    }
+
+    /**
+     * @test
+     */
+    public function multi_lazy_sequences_two_new_search_queries(): void
+    {
+        $indexName1 = uniqid();
+        $indexName2 = uniqid();
+
+        $blueprint = new NewProperties;
+        $blueprint->text('name');
+
+        $this->sigmie->newIndex($indexName1)->properties($blueprint)->create();
+        $this->sigmie->newIndex($indexName2)->properties($blueprint)->create();
+
+        $this->sigmie->collect($indexName1, refresh: true)->merge([
+            new Document(['name' => 'Alpha']),
+            new Document(['name' => 'Beta']),
+        ]);
+
+        $this->sigmie->collect($indexName2, refresh: true)->merge([
+            new Document(['name' => 'Gamma']),
+        ]);
+
+        $multi = $this->sigmie->newMultiSearch();
+
+        $multi->newSearch($indexName2)
+            ->properties($blueprint)
+            ->queryString('');
+
+        $multi->newSearch($indexName1)
+            ->properties($blueprint)
+            ->queryString('');
+
+        $hits = iterator_to_array($multi->lazy());
+
+        $this->assertCount(3, $hits);
+    }
+
+    /**
+     * @test
+     */
+    public function multi_lazy_sequences_two_new_query_match_all(): void
+    {
+        $indexName1 = uniqid();
+        $indexName2 = uniqid();
+
+        $blueprint = new NewProperties;
+        $blueprint->text('name');
+
+        $this->sigmie->newIndex($indexName1)->properties($blueprint)->create();
+        $this->sigmie->newIndex($indexName2)->properties($blueprint)->create();
+
+        $this->sigmie->collect($indexName1, refresh: true)->merge([
+            new Document(['name' => 'A']),
+            new Document(['name' => 'B']),
+        ]);
+
+        $this->sigmie->collect($indexName2, refresh: true)->merge([
+            new Document(['name' => 'C']),
+        ]);
+
+        $multi = $this->sigmie->newMultiSearch();
+
+        $multi->newQuery($indexName1)->properties($blueprint)->matchAll();
+        $multi->newQuery($indexName2)->properties($blueprint)->matchAll();
+
+        $hits = iterator_to_array($multi->lazy());
+
+        $this->assertCount(3, $hits);
+    }
+
+    /**
+     * @test
+     */
+    public function multi_lazy_includes_new_query_entries(): void
+    {
+        $indexName = uniqid();
+
+        $blueprint = new NewProperties;
+        $blueprint->text('name');
+
+        $this->sigmie->newIndex($indexName)->properties($blueprint)->create();
+
+        $this->sigmie->collect($indexName, refresh: true)->merge([
+            new Document(['name' => 'One']),
+            new Document(['name' => 'Two']),
+        ]);
+
+        $multi = $this->sigmie->newMultiSearch();
+
+        $multi->newQuery($indexName)->properties($blueprint)->matchAll();
+
+        $hits = iterator_to_array($multi->lazy());
+
+        $this->assertCount(2, $hits);
+    }
+
+    /**
+     * @test
+     */
+    public function multi_lazy_returns_generator(): void
+    {
+        $indexName = uniqid();
+
+        $blueprint = new NewProperties;
+        $blueprint->text('name');
+
+        $this->sigmie->newIndex($indexName)->properties($blueprint)->create();
+
+        $multi = $this->sigmie->newMultiSearch();
+
+        $multi->newSearch($indexName)->properties($blueprint)->queryString('');
+
+        $this->assertInstanceOf(Generator::class, $multi->lazy());
+    }
+
+    /**
+     * @test
+     */
+    public function multi_each_counts_hits(): void
+    {
+        $indexName1 = uniqid();
+        $indexName2 = uniqid();
+
+        $blueprint = new NewProperties;
+        $blueprint->text('name');
+
+        $this->sigmie->newIndex($indexName1)->properties($blueprint)->create();
+        $this->sigmie->newIndex($indexName2)->properties($blueprint)->create();
+
+        $this->sigmie->collect($indexName1, refresh: true)->merge([new Document(['name' => 'X'])]);
+        $this->sigmie->collect($indexName2, refresh: true)->merge([new Document(['name' => 'Y'])]);
+
+        $multi = $this->sigmie->newMultiSearch();
+
+        $multi->newSearch($indexName1)->properties($blueprint)->queryString('X');
+        $multi->newSearch($indexName2)->properties($blueprint)->queryString('Y');
+
+        $count = 0;
+        $multi->each(function (Hit $hit) use (&$count): void {
+            $count++;
+        });
+
+        $this->assertSame(2, $count);
+    }
+
+    /**
+     * @test
+     */
+    public function multi_lazy_includes_raw_queries(): void
+    {
+        $indexName = uniqid();
+
+        $blueprint = new NewProperties;
+        $blueprint->text('name');
+
+        $this->sigmie->newIndex($indexName)->properties($blueprint)->create();
+
+        $this->sigmie->collect($indexName, refresh: true)->merge([
+            new Document(['name' => 'Only']),
+        ]);
+
+        $multi = $this->sigmie->newMultiSearch();
+
+        $multi->newSearch($indexName)->properties($blueprint)->queryString('Only');
+
+        $multi->raw($indexName, [
+            'query' => ['match_all' => (object) []],
+        ]);
+
+        $hits = iterator_to_array($multi->lazy());
+
+        $this->assertCount(2, $hits);
     }
 }

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Sigmie\Tests;
 
+use Generator;
 use Http\Promise\Promise;
 use Sigmie\Document\Document;
+use Sigmie\Document\Hit;
 use Sigmie\Languages\English\English;
 use Sigmie\Languages\German\German;
 use Sigmie\Mappings\NewProperties;
@@ -1308,5 +1310,121 @@ class SearchTest extends TestCase
             ->get();
 
         $this->assertEquals(200, $response->code());
+    }
+
+    /**
+     * @test
+     */
+    public function lazy_returns_generator(): void
+    {
+        $indexName = uniqid();
+
+        $blueprint = new NewProperties;
+        $blueprint->text('name');
+
+        $this->sigmie->newIndex($indexName)->properties($blueprint)->create();
+
+        $gen = $this->sigmie->newSearch($indexName)
+            ->properties($blueprint)
+            ->lazy();
+
+        $this->assertInstanceOf(Generator::class, $gen);
+    }
+
+    /**
+     * @test
+     */
+    public function lazy_iterates_all_documents_across_pages(): void
+    {
+        $indexName = uniqid();
+
+        $blueprint = new NewProperties;
+        $blueprint->text('name');
+
+        $this->sigmie->newIndex($indexName)->properties($blueprint)->create();
+
+        $docs = [];
+        for ($i = 0; $i < 5; $i++) {
+            $docs[] = new Document(['name' => 'item'.$i]);
+        }
+
+        $this->sigmie->collect($indexName, refresh: true)->merge($docs);
+
+        $hits = iterator_to_array(
+            $this->sigmie->newSearch($indexName)
+                ->properties($blueprint)
+                ->chunk(2)
+                ->lazy()
+        );
+
+        $this->assertCount(5, $hits);
+        foreach ($hits as $hit) {
+            $this->assertInstanceOf(Hit::class, $hit);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function each_respects_filters_for_lazy_iteration(): void
+    {
+        $indexName = uniqid();
+
+        $blueprint = new NewProperties;
+        $blueprint->bool('active');
+
+        $this->sigmie->newIndex($indexName)->properties($blueprint)->create();
+
+        $this->sigmie->collect($indexName, refresh: true)->merge([
+            new Document(['active' => true]),
+            new Document(['active' => false]),
+            new Document(['active' => true]),
+            new Document(['active' => true]),
+        ]);
+
+        $ids = [];
+
+        $this->sigmie->newSearch($indexName)
+            ->properties($blueprint)
+            ->filters('active:true')
+            ->chunk(2)
+            ->each(function (Hit $hit) use (&$ids): void {
+                $this->assertInstanceOf(Hit::class, $hit);
+                $ids[] = $hit->_id;
+            });
+
+        $this->assertCount(3, $ids);
+    }
+
+    /**
+     * @test
+     */
+    public function each_respects_query_string_for_lazy_iteration(): void
+    {
+        $indexName = uniqid();
+
+        $blueprint = new NewProperties;
+        $blueprint->text('name');
+
+        $this->sigmie->newIndex($indexName)->properties($blueprint)->create();
+
+        $this->sigmie->collect($indexName, refresh: true)->merge([
+            new Document(['name' => 'Mickey']),
+            new Document(['name' => 'Goofy']),
+            new Document(['name' => 'Mickey Mouse']),
+        ]);
+
+        $names = [];
+
+        $this->sigmie->newSearch($indexName)
+            ->properties($blueprint)
+            ->queryString('Mickey')
+            ->each(function (Hit $hit) use (&$names): void {
+                $names[] = $hit->_source['name'];
+            });
+
+        $this->assertCount(2, $names);
+        $this->assertContains('Mickey', $names);
+        $this->assertContains('Mickey Mouse', $names);
     }
 }


### PR DESCRIPTION
## What changed

- **PIT streaming**: `PointInTimeRequests`, `PointInTimeIterator`, and `LazyIterableQuery` support full-result iteration without loading all hits at once.
- **NewSearch / NewQuery**: `lazy()` and `each()` stream hits via PIT + `search_after`; `chunk()` controls page size.
- **NewMultiSearch**: `lazy()` / `each()` walk every lazy query in registration order (nested iteration, not `yield from` on nested generators).
- **RawQuery**: `raw()` registers a `RawQuery` adapter that is both `MultiSearchable` (same `_msearch` shape and array `get()` results as before) and `LazyIterableQuery` (same PIT pipeline as `NewQuery`). `NewMultiSearch::raw()` now returns `RawQuery` so callers can `->chunk(n)` on that slot.
- **SigmieIndexTrait**: anonymous multi helper `raw()` return type updated to `RawQuery`.
- **Docs**: `docs/search.md` streaming section; `docs/document.md` updates as in branch.
- **Tests**: `MultiSearchTest` lazy sequencing and `multi_lazy_includes_raw_queries`; `SearchTest` coverage for lazy search behavior.

## Testing

- `php vendor/bin/phpunit tests/MultiSearchTest.php`
- `php vendor/bin/phpunit tests/SearchTest.php` (run locally before merge if not in CI)

## Risks

- **Breaking**: `NewMultiSearch::raw()` no longer returns `static` for chaining on the multi instance; use `$multi->raw(...)->chunk(...)` then continue with `$multi->...` for the next slot.
- External callers that typed `raw()` as `NewMultiSearch` need `RawQuery` (or a union) where applicable.

Made with [Cursor](https://cursor.com)