### PR TITLE
feat: PitSortPlanner for lazy iteration user sort

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -470,6 +470,23 @@ $sigmie->newSearch('products')
 
 A smaller chunk size reduces memory per request; a larger one reduces the number of round-trips to Elasticsearch. Tune it based on document size and your available memory.
 
+### Sort order during iteration
+
+Point-in-Time search must use a deterministic `sort` so `search_after` can page without skipping or duplicating hits. Sigmie builds that internally (via `PitSortPlanner`); you do not instantiate it yourself.
+
+- **`NewSearch`**: Your `sort('field:asc')` string still applies. Sorts that are only `_score` or `_doc` are replaced by the engine tiebreaker (`_shard_doc` ascending on Elasticsearch, `_id` ascending on OpenSearch). Any other sort list keeps your keys and appends the tiebreaker when it is not already the last sort key.
+
+- **`NewQuery`**: Pass an Elasticsearch sort array with `sort([['price' => 'asc']])` before you add the query clause (for example `matchAll()`). Omit `sort()` to stream in tiebreaker-only order (stable, not relevance-ranked). Use field names that exist in your mapping (for text fields you often need a `.keyword` or a `.sortable` subfield from your blueprint).
+
+- **`raw()` / `RawQuery`**: Include a top-level `sort` key in the body you pass to `raw()`:
+
+```php
+$multi->raw('orders', [
+    'query' => ['match_all' => (object) []],
+    'sort' => [['processed_at' => 'asc']],
+]);
+```
+
 ### Streaming hits from a multi-search
 
 `newMultiSearch()` registers several queries. A single `_msearch` call returns only the first page per query. To stream **all** matching hits across those queries, call `lazy()` or `each()` on the multi-search instance. Each registered `NewSearch`, `NewQuery`, or `raw()` body runs its own PIT iteration; the multi-search yields hits in registration order (first query fully, then the next).
@@ -498,7 +515,7 @@ foreach ($multi->lazy() as $hit) {
 
 Set `chunk()` on each query before the next registration — the multi-search object does not expose its own `chunk()`; page size is per query. `raw()` returns a `RawQuery` instance; call `chunk()` on that return value before you register the next slot if you want a non-default page size for that raw body.
 
-> **Note:** `each()` and `lazy()` ignore `from()`, `size()`, `page()`, and `highlighting()` — these are pagination and display concerns that do not apply to full iteration.
+> **Note:** `each()` and `lazy()` ignore `from()`, `size()`, `page()`, and `highlighting()` — these are pagination and display concerns that do not apply to full iteration. User-defined sort is still applied for streaming where you set it (`NewSearch::sort()`, `NewQuery::sort(array)`, or a `sort` key on a raw body); see **Sort order during iteration** above.
 
 ## Promises
 For asynchronous operations, you can get a Promise instead of executing the search immediately:

--- a/src/Query/NewQuery.php
+++ b/src/Query/NewQuery.php
@@ -31,6 +31,7 @@ use Sigmie\Query\Queries\Text\Match_;
 use Sigmie\Query\Queries\Text\MultiMatch;
 use Sigmie\Search\Contracts\LazyIterableQuery;
 use Sigmie\Search\Contracts\MultiSearchable;
+use Sigmie\Search\PitSortPlanner;
 use Sigmie\Search\PointInTimeIterator;
 
 use function Sigmie\Functions\random_name;
@@ -76,6 +77,13 @@ class NewQuery implements LazyIterableQuery, MultiSearchable, Queries
         $this->properties = $props instanceof NewProperties ? $props->get() : $props;
 
         $this->search->filterParserProperties($this->properties);
+
+        return $this;
+    }
+
+    public function sort(array $sort): static
+    {
+        $this->search->sort($sort);
 
         return $this;
     }
@@ -289,6 +297,8 @@ class NewQuery implements LazyIterableQuery, MultiSearchable, Queries
 
         $body = $this->search->toRaw();
 
+        $userSort = is_array($body['sort'] ?? null) ? $body['sort'] : [];
+
         unset(
             $body['from'],
             $body['size'],
@@ -300,7 +310,7 @@ class NewQuery implements LazyIterableQuery, MultiSearchable, Queries
         );
 
         $body['size'] = $this->pitIterationChunkSize;
-        $body['sort'] = $isOpenSearch ? [['_id' => 'asc']] : [['_shard_doc' => 'asc']];
+        $body['sort'] = PitSortPlanner::plan($userSort, $isOpenSearch);
 
         $keepAlive = '1m';
         $open = $pit->open($this->search->index, $keepAlive);

--- a/src/Search/NewSearch.php
+++ b/src/Search/NewSearch.php
@@ -1016,7 +1016,7 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
         );
 
         $body['size'] = $this->pitIterationChunkSize;
-        $body['sort'] = $this->stableSortForPitIteration();
+        $body['sort'] = PitSortPlanner::plan($this->sort, $isOpenSearch);
 
         $keepAlive = '1m';
         $open = $pit->open($this->index, $keepAlive);
@@ -1038,63 +1038,6 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
                 $data['sort'] ?? null,
             ),
         );
-    }
-
-    /**
-     * @return list<string|array<string, mixed>>
-     */
-    private function stableSortForPitIteration(): array
-    {
-        $isOpenSearch = $this->elasticsearchConnection->driver()->engine() === SearchEngineType::OpenSearch;
-        $tiebreaker = $isOpenSearch ? [['_id' => 'asc']] : [['_shard_doc' => 'asc']];
-
-        if ($this->sortUsesOnlyScoreOrDoc($this->sort)) {
-            return $tiebreaker;
-        }
-
-        return $this->appendPitTiebreakerUnlessPresent($this->sort, $tiebreaker);
-    }
-
-    /**
-     * @param  list<string|array<string, mixed>>  $sort
-     */
-    private function sortUsesOnlyScoreOrDoc(array $sort): bool
-    {
-        if ($sort === []) {
-            return true;
-        }
-
-        if ($sort === ['_score'] || $sort === ['_doc']) {
-            return true;
-        }
-
-        if (count($sort) !== 1) {
-            return false;
-        }
-
-        $only = $sort[0];
-
-        if ($only === '_score' || $only === '_doc') {
-            return true;
-        }
-
-        return is_array($only) && (isset($only['_score']) || isset($only['_doc']));
-    }
-
-    /**
-     * @param  list<string|array<string, mixed>>  $sort
-     * @param  list<array<string, string>>  $tiebreaker
-     * @return list<string|array<string, mixed>>
-     */
-    private function appendPitTiebreakerUnlessPresent(array $sort, array $tiebreaker): array
-    {
-        $last = $sort[array_key_last($sort)];
-
-        if (is_array($last) && (isset($last['_shard_doc']) || isset($last['_id']))) {
-            return $sort;
-        }
-
-        return array_merge($sort, $tiebreaker);
     }
 
     public function setVectorPool(VectorPool|array $pool, ?string $apiName = null): static

--- a/src/Search/PitSortPlanner.php
+++ b/src/Search/PitSortPlanner.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\Search;
+
+final class PitSortPlanner
+{
+    /**
+     * @param  list<string|array<string, mixed>>  $userSort
+     * @return list<string|array<string, mixed>>
+     */
+    public static function plan(array $userSort, bool $isOpenSearch): array
+    {
+        $tiebreaker = $isOpenSearch ? [['_id' => 'asc']] : [['_shard_doc' => 'asc']];
+
+        if ($userSort === [] || self::onlyScoreOrDoc($userSort)) {
+            return $tiebreaker;
+        }
+
+        return self::appendTiebreakerUnlessPresent($userSort, $tiebreaker);
+    }
+
+    /**
+     * @param  list<string|array<string, mixed>>  $sort
+     */
+    private static function onlyScoreOrDoc(array $sort): bool
+    {
+        if ($sort === []) {
+            return true;
+        }
+
+        if ($sort === ['_score'] || $sort === ['_doc']) {
+            return true;
+        }
+
+        if (count($sort) !== 1) {
+            return false;
+        }
+
+        $only = $sort[0];
+
+        if ($only === '_score' || $only === '_doc') {
+            return true;
+        }
+
+        if (is_array($only) && (isset($only['_score']) || isset($only['_doc']))) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<string|array<string, mixed>>  $sort
+     * @param  list<array<string, string>>  $tiebreaker
+     * @return list<string|array<string, mixed>>
+     */
+    private static function appendTiebreakerUnlessPresent(array $sort, array $tiebreaker): array
+    {
+        $last = $sort[array_key_last($sort)];
+
+        if (is_array($last) && (isset($last['_shard_doc']) || isset($last['_id']))) {
+            return $sort;
+        }
+
+        return array_merge($sort, $tiebreaker);
+    }
+}

--- a/src/Search/RawQuery.php
+++ b/src/Search/RawQuery.php
@@ -74,6 +74,8 @@ final class RawQuery implements LazyIterableQuery, MultiSearchable
 
         $body = $this->body;
 
+        $userSort = is_array($this->body['sort'] ?? null) ? $this->body['sort'] : [];
+
         unset(
             $body['from'],
             $body['size'],
@@ -86,7 +88,7 @@ final class RawQuery implements LazyIterableQuery, MultiSearchable
         );
 
         $body['size'] = $this->pitIterationChunkSize;
-        $body['sort'] = $isOpenSearch ? [['_id' => 'asc']] : [['_shard_doc' => 'asc']];
+        $body['sort'] = PitSortPlanner::plan($userSort, $isOpenSearch);
 
         $keepAlive = '1m';
         $open = $pit->open($this->index, $keepAlive);

--- a/tests/MultiSearchTest.php
+++ b/tests/MultiSearchTest.php
@@ -250,4 +250,66 @@ class MultiSearchTest extends TestCase
 
         $this->assertCount(2, $hits);
     }
+
+    /**
+     * @test
+     */
+    public function multi_lazy_includes_raw_queries_with_sort(): void
+    {
+        $indexName = uniqid();
+
+        $blueprint = new NewProperties;
+        $blueprint->text('name')->keyword()->makeSortable();
+
+        $this->sigmie->newIndex($indexName)->properties($blueprint)->create();
+
+        $this->sigmie->collect($indexName, refresh: true)->merge([
+            new Document(['name' => 'Charlie']),
+            new Document(['name' => 'Alice']),
+            new Document(['name' => 'Bob']),
+        ]);
+
+        $multi = $this->sigmie->newMultiSearch();
+
+        $multi->raw($indexName, [
+            'query' => ['match_all' => (object) []],
+            'sort' => [['name.sortable' => 'asc']],
+        ]);
+
+        $hits = iterator_to_array($multi->lazy());
+        $names = array_map(fn (Hit $hit): string => (string) $hit['name'], $hits);
+
+        $this->assertSame(['Alice', 'Bob', 'Charlie'], $names);
+    }
+
+    /**
+     * @test
+     */
+    public function lazy_new_query_respects_user_sort(): void
+    {
+        $indexName = uniqid();
+
+        $blueprint = new NewProperties;
+        $blueprint->text('name')->keyword()->makeSortable();
+
+        $this->sigmie->newIndex($indexName)->properties($blueprint)->create();
+
+        $this->sigmie->collect($indexName, refresh: true)->merge([
+            new Document(['name' => 'a']),
+            new Document(['name' => 'b']),
+            new Document(['name' => 'c']),
+        ]);
+
+        $multi = $this->sigmie->newMultiSearch();
+
+        $multi->newQuery($indexName)
+            ->properties($blueprint)
+            ->sort([['name.sortable' => 'desc']])
+            ->matchAll();
+
+        $hits = iterator_to_array($multi->lazy());
+        $names = array_map(fn (Hit $hit): string => (string) $hit['name'], $hits);
+
+        $this->assertSame(['c', 'b', 'a'], $names);
+    }
 }


### PR DESCRIPTION
## What changed

- **PitSortPlanner** ([`src/Search/PitSortPlanner.php`](src/Search/PitSortPlanner.php)): shared logic for PIT + `search_after` sort — tiebreaker (`_shard_doc` on Elasticsearch, `_id` on OpenSearch), score/doc-only sorts, and appending the tiebreaker when the user sort is a real field sort.
- **NewSearch**: `iterateHits()` calls `PitSortPlanner::plan(->sort, )`; removed duplicated private helpers.
- **NewQuery**: `sort(array )` delegates to `Search::sort()`; `lazy()` reads `sort` from `toRaw()` then applies the planner.
- **RawQuery**: reads `sort` from the raw body (when it is an array) and applies the planner.
- **Tests**: `multi_lazy_includes_raw_queries_with_sort`, `lazy_new_query_respects_user_sort` in [`tests/MultiSearchTest.php`](tests/MultiSearchTest.php).
- **Docs**: new subsection **Sort order during iteration** and a clarifying sentence in the multi-search streaming note in [`docs/search.md`](docs/search.md).

## Testing

`php vendor/bin/phpunit tests/MultiSearchTest.php`

## Notes

Builds on the merged multisearch / PIT / `RawQuery` work; this PR is scoped to user-defined sort during `lazy()` / `each()` for `NewSearch`, `NewQuery`, and raw bodies.

Made with [Cursor](https://cursor.com)