### PR TITLE
feat: uniqueBy() for NewSearch and sortString() for NewQuery

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -483,6 +483,15 @@ $search->sort('_score:desc year:desc');
 $search->sort('rating:desc title:asc');
 ```
 
+##### `uniqueBy(string $field, int $top = 0): self`
+
+Field collapsing: at most one hit per value of `field`. When `top` is greater than zero, the response includes inner hits named `top` with up to that many additional documents per group. The field must be single-valued in the mapping (for example `keyword`).
+
+```php
+$search->uniqueBy('composite_key');
+$search->uniqueBy('product_id', top: 3);
+```
+
 #### Pagination
 
 ##### `from(int $from): self`
@@ -723,30 +732,38 @@ Add aggregations.
 $query->facets('category');
 ```
 
-#### Sorting and Pagination
+#### Sorting (NewQuery)
+
+Call `sort` and `sortString` on `NewQuery` **before** `matchAll`, `bool`, `parse`, and other methods that return `Search`. Each `sortString` call sets the full sort; use one string with all fields, or `sort` with a raw array.
+
+##### `sort(array $sort): self`
+
+Elasticsearch sort array (same as the top-level `sort` key in the search body).
+
+```php
+$query->sort([['year' => 'desc'], ['_score' => 'desc']]);
+```
 
 ##### `sortString(string $sort): self`
 
-Set sort order.
+Parsed sort string (same syntax as `NewSearch::sort()`).
 
 ```php
 $query->sortString('year:desc _score:desc');
 ```
 
-##### `from(int $from): self`
+#### Pagination (`Search`)
 
-Set offset.
-
-```php
-$query->from(10);
-```
-
-##### `size(int $size): self`
-
-Set limit.
+`from` and `size` are on the `Search` instance returned after the query is set.
 
 ```php
-$query->size(20);
+$response = $sigmie->newQuery('movies')
+    ->properties($properties)
+    ->sortString('title:asc')
+    ->matchAll()
+    ->from(0)
+    ->size(20)
+    ->get();
 ```
 
 #### Execution

--- a/docs/query.md
+++ b/docs/query.md
@@ -4,16 +4,18 @@ short_description: Build custom Elasticsearch queries for advanced use cases
 keywords: [query, advanced query, bool query, elasticsearch dsl, custom queries]
 category: Core Concepts
 order: 6
-related_pages: [search, document, semantic-search]
+related_pages: [search, document, semantic-search, sort-parser]
 ---
 
 # Introduction
 If you are familiar with Elasticsearch and the Search functionality doesn't cover your needs, you can of course send any query that you wish to Elasticsearch using the `newQuery` method on the Sigmie client instance.
 
 Below is an example of some of the available options:
+
 ```php
 $sigmie->newQuery('disney-movies')
         ->properties($properties)
+        ->sortString('name:asc')
         ->bool(function (Boolean $boolean) {
 
             $boolean->filter()->matchAll();
@@ -29,11 +31,12 @@ $sigmie->newQuery('disney-movies')
             $boolean->should()->bool(fn (Boolean $boolean) => $boolean->must()->match('name', 'Mickey'));
 
         })
-        ->sortString('name:asc')
         ->from(0)
         ->size(15)
         ->get();
 ```
+
+Call `sortString` (or `sort` with a raw array) on `NewQuery` **before** `bool`, `matchAll`, `parse`, and other methods that return `Search`. Pagination uses `from` and `size` on that `Search` instance after the query is set.
 
 The above example uses the `get` method to execute the query and get the results. You can also use `getDSL` to get the underlying JSON query for debugging:
 
@@ -392,7 +395,7 @@ $facets = $response->json('aggregations');
 
 # Sorting
 
-By default, the returned Documents are sorted by the `_score` attribute in descending order (highest scores first). You can change this behavior using the `sortString` method:
+By default, the returned Documents are sorted by the `_score` attribute in descending order (highest scores first). You can change this behavior with `sortString` (parsed with the same rules as `NewSearch::sort()`) or with `sort` and a raw Elasticsearch sort array.
 
 ```php
 $newQuery->sortString('name:asc _score:desc');
@@ -400,11 +403,17 @@ $newQuery->sortString('name:asc _score:desc');
 
 **Note**: `_score:asc` is not allowed. Use `_score` or `_score:desc` instead.
 
-Multiple sorts can be chained:
+Put every sort field in a **single** string (space-separated). A second `sortString` call **replaces** the first; it does not append.
+
 ```php
-$newQuery->sortString('name:asc')
-        ->sortString('created_at:desc');
+$newQuery->sortString('name:asc created_at:desc');
 ```
+
+```php
+$newQuery->sort([['year' => 'desc'], ['_score' => 'desc']]);
+```
+
+Call `sortString` / `sort` on `NewQuery` before `matchAll`, `bool`, `parse`, and other methods that return `Search`.
 
 @info
 It's important to note here, that sorting on Text fields is only possible if they are mapped as Keywords.

--- a/docs/search.md
+++ b/docs/search.md
@@ -296,6 +296,31 @@ The `from` method specifies the number of records that should be skipped, while 
 
 In this example, the combination of the `from` and `size` values creates a paginated result set with 10 hits per page. You can use these methods to paginate the results of a search and split them into smaller, more manageable pages.
 
+## Deduplication
+
+When many documents share the same key (for example variants of the same product), you can return one hit per key and optionally include the next best matches from that group in the response.
+
+```php
+// One result per composite_key
+$sigmie->newSearch('jobs')
+    ->properties($properties)
+    ->queryString('')
+    ->uniqueBy('composite_key')
+    ->get();
+
+// One result per product_id, plus the top two other matches in that group (inner hits named `top`)
+$sigmie->newSearch('products')
+    ->properties($properties)
+    ->queryString('sneakers')
+    ->sort('price:asc')
+    ->uniqueBy('product_id', top: 3)
+    ->get();
+```
+
+The collapse field must be mapped as a single-valued field (for example `keyword`).
+
+`uniqueBy` is for `newSearch` only. If you use `newQuery` and a sort string, call `sortString` (or `sort` with a raw array) on the query builder before `bool`, `matchAll`, and other methods that return `Search` — see [Advanced Queries](/docs/query) and [Sort parser](/docs/sort-parser).
+
 ## Facets
 You can use facets to get aggregated information about your search results:
 
@@ -476,7 +501,7 @@ Point-in-Time search must use a deterministic `sort` so `search_after` can page 
 
 - **`NewSearch`**: Your `sort('field:asc')` string still applies. Sorts that are only `_score` or `_doc` are replaced by the engine tiebreaker (`_shard_doc` ascending on Elasticsearch, `_id` ascending on OpenSearch). Any other sort list keeps your keys and appends the tiebreaker when it is not already the last sort key.
 
-- **`NewQuery`**: Pass an Elasticsearch sort array with `sort([['price' => 'asc']])` before you add the query clause (for example `matchAll()`). Omit `sort()` to stream in tiebreaker-only order (stable, not relevance-ranked). Use field names that exist in your mapping (for text fields you often need a `.keyword` or a `.sortable` subfield from your blueprint).
+- **`NewQuery`**: Call `sortString('price:asc')` or `sort([['price' => 'asc']])` on the query builder before you add the query clause (for example `matchAll()`). Omit `sort()` to stream in tiebreaker-only order (stable, not relevance-ranked). Use field names that exist in your mapping (for text fields you often need a `.keyword` or a `.sortable` subfield from your blueprint).
 
 - **`raw()` / `RawQuery`**: Include a top-level `sort` key in the body you pass to `raw()`:
 
@@ -515,7 +540,7 @@ foreach ($multi->lazy() as $hit) {
 
 Set `chunk()` on each query before the next registration — the multi-search object does not expose its own `chunk()`; page size is per query. `raw()` returns a `RawQuery` instance; call `chunk()` on that return value before you register the next slot if you want a non-default page size for that raw body.
 
-> **Note:** `each()` and `lazy()` ignore `from()`, `size()`, `page()`, and `highlighting()` — these are pagination and display concerns that do not apply to full iteration. User-defined sort is still applied for streaming where you set it (`NewSearch::sort()`, `NewQuery::sort(array)`, or a `sort` key on a raw body); see **Sort order during iteration** above.
+> **Note:** `each()` and `lazy()` ignore `from()`, `size()`, `page()`, and `highlighting()` — these are pagination and display concerns that do not apply to full iteration. User-defined sort is still applied for streaming where you set it (`NewSearch::sort()`, `NewQuery::sortString()` / `NewQuery::sort(array)`, or a `sort` key on a raw body); see **Sort order during iteration** above.
 
 ## Promises
 For asynchronous operations, you can get a Promise instead of executing the search immediately:

--- a/docs/sort-parser.md
+++ b/docs/sort-parser.md
@@ -4,15 +4,25 @@ short_description: Parse sort expressions for search result ordering
 keywords: [sort parser, sorting, order, search results]
 category: Utilities
 order: 2
-related_pages: [search, filter-parser]
+related_pages: [search, query, filter-parser]
 ---
 
 # Sort parser
 
 ## Introduction
+
+With `NewSearch` or with `NewQuery` (call `sortString` before the query):
+
 ```php
-$newQuery->sort('_score')->sort('name.keyword', 'asc');
+$sigmie->newSearch('movies')->properties($properties)->sort('_score name:asc');
 ```
+
+```php
+$sigmie->newQuery('movies')->properties($properties)->sortString('_score name:asc');
+```
+
+Using the parser directly:
+
 ```php
 $parser->parse('_score name:asc');
 ```

--- a/src/Query/NewQuery.php
+++ b/src/Query/NewQuery.php
@@ -14,6 +14,7 @@ use Sigmie\Enums\SearchEngineType;
 use Sigmie\Mappings\NewProperties;
 use Sigmie\Mappings\Properties;
 use Sigmie\Parse\FilterParser;
+use Sigmie\Parse\SortParser;
 use Sigmie\Query\Contracts\Queries;
 use Sigmie\Query\Contracts\QueryClause as Query;
 use Sigmie\Query\Queries\Compound\Boolean;
@@ -84,6 +85,15 @@ class NewQuery implements LazyIterableQuery, MultiSearchable, Queries
     public function sort(array $sort): static
     {
         $this->search->sort($sort);
+
+        return $this;
+    }
+
+    public function sortString(string $sort): static
+    {
+        $parser = new SortParser($this->properties, true);
+
+        $this->search->sort($parser->parse($sort));
 
         return $this;
     }

--- a/src/Search/NewSearch.php
+++ b/src/Search/NewSearch.php
@@ -78,6 +78,10 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
 
     protected int $pitIterationChunkSize = 500;
 
+    protected ?string $collapseField = null;
+
+    protected int $collapseTop = 0;
+
     public function __construct(
         ElasticsearchConnection $elasticsearchConnection
     ) {
@@ -219,6 +223,14 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
         return $this;
     }
 
+    public function uniqueBy(string $field, int $top = 0): static
+    {
+        $this->collapseField = $field;
+        $this->collapseTop = $top;
+
+        return $this;
+    }
+
     protected function handleHighlight(Search $search)
     {
         $highlight = new Collection($this->highlight);
@@ -288,6 +300,24 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
     protected function handleSort(Search $search)
     {
         $search->addRaw('sort', $this->sort);
+    }
+
+    protected function handleCollapse(Search $search): void
+    {
+        if ($this->collapseField === null) {
+            return;
+        }
+
+        $collapse = ['field' => $this->collapseField];
+
+        if ($this->collapseTop > 0) {
+            $collapse['inner_hits'] = [
+                'name' => 'top',
+                'size' => $this->collapseTop,
+            ];
+        }
+
+        $search->addRaw('collapse', $collapse);
     }
 
     protected function handleMinScore(Search $search)
@@ -414,6 +444,8 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
         $search->query($query);
 
         $this->handlePostFilter($search);
+
+        $this->handleCollapse($search);
 
         return $search;
     }

--- a/src/Search/PitSortPlanner.php
+++ b/src/Search/PitSortPlanner.php
@@ -44,11 +44,7 @@ final class PitSortPlanner
             return true;
         }
 
-        if (is_array($only) && (isset($only['_score']) || isset($only['_doc']))) {
-            return true;
-        }
-
-        return false;
+        return is_array($only) && (isset($only['_score']) || isset($only['_doc']));
     }
 
     /**

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -352,4 +352,35 @@ class QueryTest extends TestCase
 
         $this->assertEquals(2, $res->json()['hits']['total']['value']);
     }
+
+    /**
+     * @test
+     */
+    public function sort_string_parses_and_sorts_results(): void
+    {
+        $indexName = uniqid();
+
+        $blueprint = new NewProperties;
+        $blueprint->text('category')->keyword()->makeSortable();
+
+        $this->sigmie->newIndex($indexName)
+            ->properties($blueprint)
+            ->create();
+
+        $this->sigmie->collect($indexName, refresh: true)->merge([
+            new Document(['category' => 'a']),
+            new Document(['category' => 'b']),
+        ]);
+
+        $res = $this->sigmie->newQuery($indexName)
+            ->properties($blueprint)
+            ->sortString('category:desc')
+            ->matchAll()
+            ->get();
+
+        $hits = $res->json('hits.hits');
+
+        $this->assertEquals('b', $hits[0]['_source']['category']);
+        $this->assertEquals('a', $hits[1]['_source']['category']);
+    }
 }

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -1427,4 +1427,86 @@ class SearchTest extends TestCase
         $this->assertContains('Mickey', $names);
         $this->assertContains('Mickey Mouse', $names);
     }
+
+    /**
+     * @test
+     */
+    public function unique_by_collapses_results_by_field(): void
+    {
+        $indexName = uniqid();
+
+        $blueprint = new NewProperties;
+        $blueprint->keyword('product_id');
+        $blueprint->integer('ord');
+
+        $this->sigmie->newIndex($indexName)
+            ->properties($blueprint)
+            ->create();
+
+        $this->sigmie->collect($indexName, refresh: true)->merge([
+            new Document(['product_id' => 'A', 'ord' => 1]),
+            new Document(['product_id' => 'A', 'ord' => 2]),
+            new Document(['product_id' => 'B', 'ord' => 3]),
+        ]);
+
+        $res = $this->sigmie->newSearch($indexName)
+            ->properties($blueprint)
+            ->queryString('')
+            ->sort('ord:asc')
+            ->uniqueBy('product_id')
+            ->get();
+
+        $hits = $res->json('hits');
+
+        $this->assertCount(2, $hits);
+    }
+
+    /**
+     * @test
+     */
+    public function unique_by_with_top_returns_inner_hits(): void
+    {
+        $indexName = uniqid();
+
+        $blueprint = new NewProperties;
+        $blueprint->keyword('product_id');
+        $blueprint->integer('ord');
+
+        $this->sigmie->newIndex($indexName)
+            ->properties($blueprint)
+            ->create();
+
+        $this->sigmie->collect($indexName, refresh: true)->merge([
+            new Document(['product_id' => 'A', 'ord' => 1]),
+            new Document(['product_id' => 'A', 'ord' => 2]),
+            new Document(['product_id' => 'A', 'ord' => 3]),
+            new Document(['product_id' => 'B', 'ord' => 0]),
+        ]);
+
+        $res = $this->sigmie->newSearch($indexName)
+            ->properties($blueprint)
+            ->queryString('')
+            ->sort('ord:asc')
+            ->uniqueBy('product_id', top: 2)
+            ->get();
+
+        $hits = $res->json('hits');
+        $this->assertCount(2, $hits);
+
+        $groupA = null;
+        foreach ($hits as $hit) {
+            if ($hit['_source']['product_id'] === 'A') {
+                $groupA = $hit;
+                break;
+            }
+        }
+
+        $this->assertNotNull($groupA);
+        $this->assertArrayHasKey('inner_hits', $groupA);
+        $this->assertArrayHasKey('top', $groupA['inner_hits']);
+        $this->assertCount(
+            2,
+            $groupA['inner_hits']['top']['hits']['hits']
+        );
+    }
 }


### PR DESCRIPTION
## Problem

Collapsing duplicate results by a field (e.g. one hit per `product_id` or `composite_key`) required reaching into raw Elasticsearch DSL:

```php
$search->addRaw('collapse', ['field' => 'composite_key']);
```

This exposes implementation details and requires knowledge of the Elasticsearch `collapse` parameter.

`NewQuery::sort()` only accepted a raw array, while `NewSearch::sort()` already supported a friendlier string syntax (`'name:asc year:desc'`). There was no equivalent for `NewQuery`.

## Solution

### `NewSearch::uniqueBy(string $field, int $top = 0)`

Wraps Elasticsearch field collapsing behind a readable API. When `top > 0`, the response includes inner hits named `top` with up to that many additional documents per group.

```php
// One result per field value
->uniqueBy('composite_key')

// One result per product_id, plus the top 3 within each group
->uniqueBy('product_id', top: 3)
```

The `top` parameter name was chosen over `innerHits` (Elasticsearch jargon) or `variants` (too product-centric) because it reads naturally in any domain.

### `NewQuery::sortString(string $sort)`

Parses the same sort string syntax as `NewSearch::sort()` via `SortParser`. Existing `sort(array)` is unchanged — no breaking changes.

```php
$sigmie->newQuery($index)
    ->properties($properties)
    ->sortString('name:asc year:desc')
    ->matchAll()
    ->get();
```

> Call `sortString` / `sort` on `NewQuery` **before** `bool`, `matchAll`, `parse`, and other methods that return `Search`.

## Testing

- `unique_by_collapses_results_by_field` — indexes two docs with the same `product_id`, asserts one hit returned
- `unique_by_with_top_returns_inner_hits` — indexes three docs for group A and one for group B, asserts two collapsed hits and inner hits present for group A
- `sort_string_parses_and_sorts_results` — indexes two docs with a sortable keyword field, asserts correct descending order via `sortString`

## Risks

- `uniqueBy` is `NewSearch`-only. `NewQuery` users can still use `addRaw('collapse', ...)` as before.
- The `collapse` field must be single-valued in the mapping (Elasticsearch requirement — documented).

## Related

No issue.

Made with [Cursor](https://cursor.com)