### PR TITLE
fix: extract text strings from document arrays in InfinityRerankApi

### DIFF
--- a/src/AI/APIs/InfinityRerankApi.php
+++ b/src/AI/APIs/InfinityRerankApi.php
@@ -27,10 +27,15 @@ class InfinityRerankApi implements RerankApi
 
     public function rerank(array $newIndexes, string $query, ?int $topK = null): array
     {
+        $documents = array_map(
+            static fn (mixed $doc): string => is_array($doc) ? (string) ($doc['text'] ?? '') : (string) $doc,
+            $newIndexes,
+        );
+
         $payload = [
             'model' => $this->model,
             'query' => $query,
-            'documents' => $newIndexes,
+            'documents' => $documents,
         ];
 
         if ($topK !== null) {

--- a/src/Search/PitSortPlanner.php
+++ b/src/Search/PitSortPlanner.php
@@ -44,11 +44,7 @@ final class PitSortPlanner
             return true;
         }
 
-        if (is_array($only) && (isset($only['_score']) || isset($only['_doc']))) {
-            return true;
-        }
-
-        return false;
+        return is_array($only) && (isset($only['_score']) || isset($only['_doc']));
     }
 
     /**


### PR DESCRIPTION
## Problem

`ApiAssertionsExampleTest::example_rerank_assertions` was failing with a 422 from the Infinity rerank endpoint:

```
Input should be a valid string — input: {"id":"1","text":"alpha"}
```

The Infinity `/rerank` API only accepts `documents` as a plain array of strings. When a caller passes associative arrays (`['id' => '1', 'text' => 'alpha']`), `InfinityRerankApi` forwarded them unchanged, causing the 422.

## Solution

In `InfinityRerankApi::rerank()`, map each document element through a normaliser before building the payload:

- If the element is an array, extract its `text` key.
- If it is already a string, pass it through unchanged.

Production callers (`NewRerank`, `Semantic/Reranker`) always pass plain strings, so they are unaffected. The one-line change is fully backwards compatible.

```php
$documents = array_map(
    static fn (mixed $doc): string => is_array($doc) ? (string) ($doc['text'] ?? '') : (string) $doc,
    $newIndexes,
);
```

## Testing

- `example_rerank_assertions` in `ApiAssertionsExampleTest` now passes.
- No other rerank tests changed.

## Risks

None — production callers pass strings; the new branch (`is_array`) is only hit for the array form.

Made with [Cursor](https://cursor.com)