### PR TITLE
Fix lazy() PIT iteration with collapse; drop final on PIT classes

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -512,6 +512,8 @@ $multi->raw('orders', [
 ]);
 ```
 
+When the request body includes `collapse`, Sigmie does not append `_shard_doc` / `_id`. Elasticsearch only allows a single sort key with `collapse` + `search_after`; supply that sort yourself (usually the collapsed field).
+
 ### Streaming hits from a multi-search
 
 `newMultiSearch()` registers several queries. A single `_msearch` call returns only the first page per query. To stream **all** matching hits across those queries, call `lazy()` or `each()` on the multi-search instance. Each registered `NewSearch`, `NewQuery`, or `raw()` body runs its own PIT iteration; the multi-search yields hits in registration order (first query fully, then the next).

--- a/src/Base/Http/PointInTimeRequests.php
+++ b/src/Base/Http/PointInTimeRequests.php
@@ -10,7 +10,7 @@ use Sigmie\Base\Contracts\ElasticsearchResponse;
 use Sigmie\Base\Http\Requests\Search as SearchRequest;
 use Sigmie\Enums\SearchEngineType;
 
-final class PointInTimeRequests
+class PointInTimeRequests
 {
     public function __construct(
         private ElasticsearchConnection $connection,

--- a/src/Query/NewQuery.php
+++ b/src/Query/NewQuery.php
@@ -307,6 +307,7 @@ class NewQuery implements LazyIterableQuery, MultiSearchable, Queries
 
         $body = $this->search->toRaw();
 
+        $hasCollapse = array_key_exists('collapse', $body);
         $userSort = is_array($body['sort'] ?? null) ? $body['sort'] : [];
 
         unset(
@@ -320,7 +321,7 @@ class NewQuery implements LazyIterableQuery, MultiSearchable, Queries
         );
 
         $body['size'] = $this->pitIterationChunkSize;
-        $body['sort'] = PitSortPlanner::plan($userSort, $isOpenSearch);
+        $body['sort'] = PitSortPlanner::plan($userSort, $isOpenSearch, $hasCollapse);
 
         $keepAlive = '1m';
         $open = $pit->open($this->search->index, $keepAlive);

--- a/src/Search/NewSearch.php
+++ b/src/Search/NewSearch.php
@@ -1037,6 +1037,8 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
 
         $body = $this->makeSearch()->toRaw();
 
+        $hasCollapse = array_key_exists('collapse', $body);
+
         unset(
             $body['from'],
             $body['size'],
@@ -1048,7 +1050,7 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
         );
 
         $body['size'] = $this->pitIterationChunkSize;
-        $body['sort'] = PitSortPlanner::plan($this->sort, $isOpenSearch);
+        $body['sort'] = PitSortPlanner::plan($this->sort, $isOpenSearch, $hasCollapse);
 
         $keepAlive = '1m';
         $open = $pit->open($this->index, $keepAlive);

--- a/src/Search/PitSortPlanner.php
+++ b/src/Search/PitSortPlanner.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sigmie\Search;
 
-final class PitSortPlanner
+class PitSortPlanner
 {
     /**
      * When `$hasCollapse` is true, returns `$userSort` unchanged. Elasticsearch allows only one

--- a/src/Search/PitSortPlanner.php
+++ b/src/Search/PitSortPlanner.php
@@ -7,11 +7,18 @@ namespace Sigmie\Search;
 final class PitSortPlanner
 {
     /**
+     * When `$hasCollapse` is true, returns `$userSort` unchanged. Elasticsearch allows only one
+     * sort field with `collapse` + `search_after`; the tiebreaker would violate that rule.
+     *
      * @param  list<string|array<string, mixed>>  $userSort
      * @return list<string|array<string, mixed>>
      */
-    public static function plan(array $userSort, bool $isOpenSearch): array
+    public static function plan(array $userSort, bool $isOpenSearch, bool $hasCollapse = false): array
     {
+        if ($hasCollapse) {
+            return $userSort;
+        }
+
         $tiebreaker = $isOpenSearch ? [['_id' => 'asc']] : [['_shard_doc' => 'asc']];
 
         if ($userSort === [] || self::onlyScoreOrDoc($userSort)) {

--- a/src/Search/PointInTimeIterator.php
+++ b/src/Search/PointInTimeIterator.php
@@ -7,7 +7,7 @@ namespace Sigmie\Search;
 use Generator;
 use Sigmie\Base\Contracts\ElasticsearchResponse;
 
-final class PointInTimeIterator
+class PointInTimeIterator
 {
     public static function pitIdFromOpenResponse(ElasticsearchResponse $response, bool $isOpenSearch): string
     {

--- a/src/Search/RawQuery.php
+++ b/src/Search/RawQuery.php
@@ -14,7 +14,7 @@ use Sigmie\Enums\SearchEngineType;
 use Sigmie\Search\Contracts\LazyIterableQuery;
 use Sigmie\Search\Contracts\MultiSearchable;
 
-final class RawQuery implements LazyIterableQuery, MultiSearchable
+class RawQuery implements LazyIterableQuery, MultiSearchable
 {
     private int $pitIterationChunkSize = 500;
 

--- a/src/Search/RawQuery.php
+++ b/src/Search/RawQuery.php
@@ -74,6 +74,7 @@ final class RawQuery implements LazyIterableQuery, MultiSearchable
 
         $body = $this->body;
 
+        $hasCollapse = array_key_exists('collapse', $this->body);
         $userSort = is_array($this->body['sort'] ?? null) ? $this->body['sort'] : [];
 
         unset(
@@ -88,7 +89,7 @@ final class RawQuery implements LazyIterableQuery, MultiSearchable
         );
 
         $body['size'] = $this->pitIterationChunkSize;
-        $body['sort'] = PitSortPlanner::plan($userSort, $isOpenSearch);
+        $body['sort'] = PitSortPlanner::plan($userSort, $isOpenSearch, $hasCollapse);
 
         $keepAlive = '1m';
         $open = $pit->open($this->index, $keepAlive);

--- a/tests/PitSortPlannerTest.php
+++ b/tests/PitSortPlannerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Sigmie\Search\PitSortPlanner;
+
+class PitSortPlannerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function collapse_skips_tiebreaker_and_preserves_user_sort(): void
+    {
+        $userSort = [['price' => 'asc']];
+
+        $planned = PitSortPlanner::plan($userSort, isOpenSearch: false, hasCollapse: true);
+
+        $this->assertSame($userSort, $planned);
+    }
+
+    /**
+     * @test
+     */
+    public function collapse_with_empty_sort_returns_empty(): void
+    {
+        $planned = PitSortPlanner::plan([], isOpenSearch: false, hasCollapse: true);
+
+        $this->assertSame([], $planned);
+    }
+
+    /**
+     * @test
+     */
+    public function without_collapse_appends_shard_doc_on_elasticsearch(): void
+    {
+        $planned = PitSortPlanner::plan([['price' => 'asc']], isOpenSearch: false, hasCollapse: false);
+
+        $this->assertSame([
+            ['price' => 'asc'],
+            ['_shard_doc' => 'asc'],
+        ], $planned);
+    }
+
+    /**
+     * @test
+     */
+    public function without_collapse_appends_id_on_opensearch(): void
+    {
+        $planned = PitSortPlanner::plan([['price' => 'asc']], isOpenSearch: true, hasCollapse: false);
+
+        $this->assertSame([
+            ['price' => 'asc'],
+            ['_id' => 'asc'],
+        ], $planned);
+    }
+}


### PR DESCRIPTION
## Problem

Elasticsearch rejects multiple `sort` keys when `collapse` is combined with `search_after`. Sigmie's PIT iterator always appended `_shard_doc` (or `_id` on OpenSearch) via `PitSortPlanner`, so `lazy()` / `each()` with a collapsed raw query returned 400.

## Solution

- When the request body includes `collapse`, `PitSortPlanner::plan()` returns the user sort unchanged (no tiebreaker). Callers must supply a single valid sort for collapse + search_after (documented in `docs/search.md`).
- Applied in `RawQuery`, `NewQuery`, and `NewSearch` iteration paths.

## Other

- Removed the `final` modifier from `RawQuery`, `PitSortPlanner`, `PointInTimeIterator`, and `PointInTimeRequests` so subclasses can extend them in downstream packages.

## Testing

- `./vendor/bin/phpunit tests/PitSortPlannerTest.php`

Made with [Cursor](https://cursor.com)