### PR TITLE
Add Laravel AI SDK tool integration

### DIFF
--- a/docs/laravel-ai.md
+++ b/docs/laravel-ai.md
@@ -1,0 +1,238 @@
+---
+title: Laravel AI SDK
+short_description: Expose Sigmie indices as tools for Laravel AI agents
+keywords: [laravel ai, ai sdk, tools, agents, llm, ai tools]
+category: Integrations
+order: 2
+related_pages: [search, filter-parser, sort-parser, facets, laravel-scout]
+---
+
+# Laravel AI SDK
+
+## Introduction
+
+When building AI agents, you often need the LLM to query or find documents in an index. Sigmie integrates with the [Laravel AI SDK](https://laravel.com/docs/13.x/ai-sdk) so you can expose any index as a tool — the AI gets search, filtering, sorting, and faceting out of the box.
+
+The `SigmieIndexTool` class wraps a `SigmieIndex` and implements Laravel AI's `Tool` interface. It auto-generates a description from your index properties, so the AI knows what fields exist and how to filter on each one.
+
+## Quick Start
+
+```php
+use Sigmie\AI\SigmieIndexTool;
+
+class ShoppingAssistant implements Agent, HasTools
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return 'You help users find products in our catalog.';
+    }
+
+    public function tools(): array
+    {
+        return [
+            new SigmieIndexTool(app(ProductIndex::class)),
+        ];
+    }
+}
+```
+
+That's it. The AI can now search the `products` index, filter by any field, sort results, and request facets.
+
+## The `AsTool` Trait
+
+For convenience, add the `AsTool` trait to your index class and call `toTool()`:
+
+```php
+use Sigmie\AI\AsTool;
+use Sigmie\SigmieIndex;
+
+class ProductIndex extends SigmieIndex
+{
+    use AsTool;
+
+    public function name(): string
+    {
+        return 'products';
+    }
+
+    public function properties(): NewProperties
+    {
+        $props = new NewProperties;
+        $props->name('name');
+        $props->category('brand');
+        $props->number('price');
+        $props->boolean('in_stock');
+        return $props;
+    }
+}
+```
+
+```php
+public function tools(): array
+{
+    return [
+        app(ProductIndex::class)->toTool(),
+    ];
+}
+```
+
+## Base Filters
+
+Pass `baseFilters` to scope every query the AI makes. This is useful for multi-tenancy or authorization — the AI never sees or can bypass these filters:
+
+```php
+new SigmieIndexTool(
+    app(OrderIndex::class),
+    baseFilters: "user_id:{$user->id}",
+)
+
+// or via the trait
+app(OrderIndex::class)->toTool(baseFilters: "user_id:{$user->id}")
+```
+
+Base filters are wrapped in parentheses and AND'd with the AI's filters, so precedence is always correct:
+
+```
+(user_id:3) AND (status:'shipped' OR status:'delivered')
+```
+
+## Auto-Generated Description
+
+The tool description is built from your index properties. The AI sees the field names, types, capabilities, and filter syntax examples. For an index with:
+
+```php
+$props->name('name');
+$props->category('brand');
+$props->number('price');
+$props->boolean('in_stock');
+$props->date('created_at');
+```
+
+The generated description looks like:
+
+```
+Search the 'products' index.
+
+Available fields:
+- name [text] (sortable, facetable): name:'value' name:['a','b']
+- brand [text] (sortable, facetable): brand:'value' brand:['a','b']
+- price [number] (sortable, facetable): price>n price<=n price:min..max
+- in_stock [boolean] (sortable): in_stock:true in_stock:false
+- created_at [date] (sortable): created_at>'2024-01-01' created_at<'2024-12-31'
+
+Filter operators: AND, OR, AND NOT
+Negation: NOT field:'value'
+Grouping: (field:'a' OR field:'b') AND other>10
+Exists check: field:*
+Sort: field:asc field:desc _score (space-separated)
+Geo sort: field[lat,lon]:km:asc
+Facets: field1 field2:20 (space-separated, optional :size for keywords or :interval for numbers)
+```
+
+## Tool Parameters
+
+The AI receives these parameters in the tool schema:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | string (required) | Search query text |
+| `filters` | string | Filter expression |
+| `sort` | string | Sort expression |
+| `facets` | string | Space-separated facet fields |
+| `facet_filters` | string | Active facet filter values |
+| `per_page` | integer (default 10) | Results per page |
+| `page` | integer (default 1) | Page number |
+
+## Filter Syntax by Field Type
+
+The filter syntax follows the [Filter Parser](filter-parser.md) rules. Each field type supports different operators:
+
+### Keyword
+
+```
+brand:'toyota'
+brand:['toyota','honda','ford']
+brand:toy*
+```
+
+### Number / Price
+
+```
+price>100
+price<=50
+price:10..100
+```
+
+### Boolean
+
+```
+in_stock:true
+in_stock:false
+```
+
+### Date
+
+```
+created_at>'2024-01-01'
+created_at<'2024-12-31'
+```
+
+### Geo
+
+```
+location:10km[40.71,-74.00]
+```
+
+### Nested
+
+Nested fields use curly braces. Sub-field filters go inside:
+
+```
+variants:{color:'red' AND size>10}
+```
+
+### Object
+
+Object fields use dot notation, just like regular fields:
+
+```
+meta.author:'John'
+```
+
+### Combining Filters
+
+```
+brand:'toyota' AND price:10000..50000
+(brand:'toyota' OR brand:'honda') AND in_stock:true
+NOT status:'discontinued'
+brand:'toyota' AND NOT color:'red'
+```
+
+## Sorting
+
+Sort expressions are space-separated. Each field can specify `:asc` or `:desc`:
+
+```
+price:asc
+created_at:desc price:asc
+_score
+```
+
+Geo fields have a special sort syntax:
+
+```
+location[40.71,-74.00]:km:asc
+```
+
+## Facets
+
+Request facets by listing field names. Optionally pass a size (for keywords) or interval (for numbers) after a colon:
+
+```
+brand
+brand:20 price:50
+```
+
+The tool response includes a `facets` key with aggregation data when facets are requested.

--- a/src/AI/AsTool.php
+++ b/src/AI/AsTool.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\AI;
+
+/**
+ * Adds a toTool() factory method to a SigmieIndex.
+ *
+ * Requires `laravel/ai` to be installed.
+ *
+ * Usage:
+ *   class ProductIndex extends SigmieIndex
+ *   {
+ *       use AsTool;
+ *       // ...
+ *   }
+ *
+ *   // In your agent:
+ *   public function tools(): array
+ *   {
+ *       return [
+ *           app(ProductIndex::class)->toTool(),
+ *           app(OrderIndex::class)->toTool(baseFilters: "user_id:{$this->user->id}"),
+ *       ];
+ *   }
+ */
+trait AsTool
+{
+    public function toTool(string $baseFilters = ''): SigmieIndexTool
+    {
+        return new SigmieIndexTool($this, $baseFilters);
+    }
+}

--- a/src/AI/SigmieIndexTool.php
+++ b/src/AI/SigmieIndexTool.php
@@ -52,22 +52,20 @@ class SigmieIndexTool implements Tool
 
         $fieldDescriptions = $this->collectFieldDescriptions($properties->toArray());
 
-        $description = "Search the '{$this->index->name()}' index.";
+        $description = sprintf("Search the '%s' index.", $this->index->name());
 
         if ($fieldDescriptions !== []) {
-            $description .= "\n\nAvailable fields:\n" . implode("\n", $fieldDescriptions);
+            $description .= "\n\nAvailable fields:\n".implode("\n", $fieldDescriptions);
         }
 
-        $description .= "\n\n"
-            . "Filter operators: AND, OR, AND NOT\n"
-            . "Negation: NOT field:'value'\n"
-            . "Grouping: (field:'a' OR field:'b') AND other>10\n"
-            . "Exists check: field:*\n"
-            . "Sort: field:asc field:desc _score (space-separated)\n"
-            . "Geo sort: field[lat,lon]:km:asc\n"
-            . "Facets: field1 field2:20 (space-separated, optional :size for keywords or :interval for numbers)";
-
-        return $description;
+        return $description.("\n\n"
+            ."Filter operators: AND, OR, AND NOT\n"
+            ."Negation: NOT field:'value'\n"
+            ."Grouping: (field:'a' OR field:'b') AND other>10\n"
+            ."Exists check: field:*\n"
+            ."Sort: field:asc field:desc _score (space-separated)\n"
+            ."Geo sort: field[lat,lon]:km:asc\n"
+            .'Facets: field1 field2:20 (space-separated, optional :size for keywords or :interval for numbers)');
     }
 
     public function schema(JsonSchema $schema): array
@@ -95,11 +93,11 @@ class SigmieIndexTool implements Tool
         $filterParts = [];
 
         if ($this->baseFilters !== '') {
-            $filterParts[] = "({$this->baseFilters})";
+            $filterParts[] = sprintf('(%s)', $this->baseFilters);
         }
 
         if ($aiFilters = $request['filters'] ?? null) {
-            $filterParts[] = "({$aiFilters})";
+            $filterParts[] = sprintf('(%s)', $aiFilters);
         }
 
         if ($filterParts !== []) {
@@ -141,7 +139,7 @@ class SigmieIndexTool implements Tool
         $descriptions = [];
 
         foreach ($fields as $field) {
-            $name = $prefix !== '' ? "{$prefix}.{$field->name}" : $field->name;
+            $name = $prefix !== '' ? sprintf('%s.%s', $prefix, $field->name) : $field->name;
 
             if ($field instanceof Object_) {
                 $descriptions = [
@@ -176,27 +174,27 @@ class SigmieIndexTool implements Tool
         $capabilities = $this->fieldCapabilities($field);
         $filter = $this->filterExample($field, $name);
 
-        $tags = $capabilities !== [] ? ' (' . implode(', ', $capabilities) . ')' : '';
+        $tags = $capabilities !== [] ? ' ('.implode(', ', $capabilities).')' : '';
 
         if ($field instanceof Nested) {
             return $this->describeNested($field, $name, $tags);
         }
 
-        return "- {$name} [{$type}]{$tags}: {$filter}";
+        return sprintf('- %s [%s]%s: %s', $name, $type, $tags, $filter);
     }
 
     private function describeNested(Nested $field, string $name, string $tags): string
     {
         $subFields = array_filter(array_map(
-            fn (Type $child) => $this->describeField($child, $child->name),
+            fn (Type $child): ?string => $this->describeField($child, $child->name),
             $field->getProperties()->toArray()
         ));
 
-        $desc = "- {$name} [nested]{$tags}: {$name}:{subfield:'value' AND other>10}";
+        $desc = sprintf("- %s [nested]%s: %s:{subfield:'value' AND other>10}", $name, $tags, $name);
 
         if ($subFields !== []) {
-            $desc .= "\n  Sub-fields:\n" . implode("\n", array_map(
-                fn (string $line) => "  {$line}",
+            $desc .= "\n  Sub-fields:\n".implode("\n", array_map(
+                fn (string $line): string => '  '.$line,
                 $subFields
             ));
         }
@@ -247,16 +245,16 @@ class SigmieIndexTool implements Tool
     {
         return match (true) {
             $field instanceof Keyword,
-            $field instanceof CaseSensitiveKeyword => "{$name}:'value' {$name}:['a','b'] {$name}:val*",
+            $field instanceof CaseSensitiveKeyword => sprintf("%s:'value' %s:['a','b'] %s:val*", $name, $name, $name),
             $field instanceof Number,
-            $field instanceof Price => "{$name}>n {$name}<=n {$name}:min..max",
-            $field instanceof Boolean => "{$name}:true {$name}:false",
+            $field instanceof Price => sprintf('%s>n %s<=n %s:min..max', $name, $name, $name),
+            $field instanceof Boolean => sprintf('%s:true %s:false', $name, $name),
             $field instanceof Date,
-            $field instanceof DateTime => "{$name}>'2024-01-01' {$name}<'2024-12-31'",
-            $field instanceof GeoPoint => "{$name}:10km[lat,lon]",
-            $field instanceof Range => "{$name}>n {$name}:min..max",
+            $field instanceof DateTime => sprintf("%s>'2024-01-01' %s<'2024-12-31'", $name, $name),
+            $field instanceof GeoPoint => $name.':10km[lat,lon]',
+            $field instanceof Range => sprintf('%s>n %s:min..max', $name, $name),
             $field instanceof Text => $field->isFilterable()
-                ? "{$name}:'value' {$name}:['a','b']"
+                ? sprintf("%s:'value' %s:['a','b']", $name, $name)
                 : 'query only',
             default => '',
         };

--- a/src/AI/SigmieIndexTool.php
+++ b/src/AI/SigmieIndexTool.php
@@ -84,7 +84,7 @@ class SigmieIndexTool implements Tool
     public function handle(Request $request): string
     {
         $search = $this->index->newSearch()
-            ->queryString((string) $request->string('query'))
+            ->queryString($request->string('query'))
             ->page(
                 $request->integer('page', 1),
                 $request->integer('per_page', 10),

--- a/src/AI/SigmieIndexTool.php
+++ b/src/AI/SigmieIndexTool.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\AI;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Sigmie\Mappings\Types\Boolean;
+use Sigmie\Mappings\Types\CaseSensitiveKeyword;
+use Sigmie\Mappings\Types\Date;
+use Sigmie\Mappings\Types\DateTime;
+use Sigmie\Mappings\Types\GeoPoint;
+use Sigmie\Mappings\Types\Keyword;
+use Sigmie\Mappings\Types\Nested;
+use Sigmie\Mappings\Types\Number;
+use Sigmie\Mappings\Types\Object_;
+use Sigmie\Mappings\Types\Price;
+use Sigmie\Mappings\Types\Range;
+use Sigmie\Mappings\Types\Text;
+use Sigmie\Mappings\Types\Type;
+use Sigmie\SigmieIndex;
+
+/**
+ * Exposes a Sigmie index as a Laravel AI SDK tool.
+ *
+ * Requires `laravel/ai` to be installed.
+ *
+ * Usage:
+ *   new SigmieIndexTool(app(ProductIndex::class))
+ *   new SigmieIndexTool(app(OrderIndex::class), baseFilters: "user_id:{$user->id}")
+ *
+ *   // In your agent:
+ *   public function tools(): array
+ *   {
+ *       return [
+ *           new SigmieIndexTool(app(ProductIndex::class)),
+ *       ];
+ *   }
+ */
+class SigmieIndexTool implements Tool
+{
+    public function __construct(
+        protected SigmieIndex $index,
+        protected string $baseFilters = '',
+    ) {}
+
+    public function description(): string
+    {
+        $properties = $this->index->properties()->get();
+
+        $fieldDescriptions = $this->collectFieldDescriptions($properties->toArray());
+
+        $description = "Search the '{$this->index->name()}' index.";
+
+        if ($fieldDescriptions !== []) {
+            $description .= "\n\nAvailable fields:\n" . implode("\n", $fieldDescriptions);
+        }
+
+        $description .= "\n\n"
+            . "Filter operators: AND, OR, AND NOT\n"
+            . "Negation: NOT field:'value'\n"
+            . "Grouping: (field:'a' OR field:'b') AND other>10\n"
+            . "Exists check: field:*\n"
+            . "Sort: field:asc field:desc _score (space-separated)\n"
+            . "Geo sort: field[lat,lon]:km:asc\n"
+            . "Facets: field1 field2:20 (space-separated, optional :size for keywords or :interval for numbers)";
+
+        return $description;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'query' => $schema->string()->description('Search query text')->required(),
+            'filters' => $schema->string()->description('Filter expression'),
+            'sort' => $schema->string()->description('Sort expression'),
+            'facets' => $schema->string()->description('Space-separated facet fields'),
+            'facet_filters' => $schema->string()->description('Active facet filter values'),
+            'per_page' => $schema->integer()->description('Number of results per page')->default(10),
+            'page' => $schema->integer()->description('Page number')->default(1),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        $search = $this->index->newSearch()
+            ->queryString((string) $request->string('query'))
+            ->page(
+                $request->integer('page', 1),
+                $request->integer('per_page', 10),
+            );
+
+        $filterParts = [];
+
+        if ($this->baseFilters !== '') {
+            $filterParts[] = "({$this->baseFilters})";
+        }
+
+        if ($aiFilters = $request['filters'] ?? null) {
+            $filterParts[] = "({$aiFilters})";
+        }
+
+        if ($filterParts !== []) {
+            $search->filters(implode(' AND ', $filterParts));
+        }
+
+        if ($sort = $request['sort'] ?? null) {
+            $search->sort((string) $sort);
+        }
+
+        if ($facets = $request['facets'] ?? null) {
+            $search->facets(
+                (string) $facets,
+                (string) ($request['facet_filters'] ?? ''),
+            );
+        }
+
+        $response = $search->get();
+
+        $hits = array_map(
+            fn ($hit) => ['_id' => $hit->_id, ...$hit->_source],
+            $response->hits()
+        );
+
+        $result = [
+            'total' => $response->total(),
+            'hits' => $hits,
+        ];
+
+        if ($facets) {
+            $result['facets'] = $response->json('facets');
+        }
+
+        return json_encode($result, JSON_PRETTY_PRINT);
+    }
+
+    private function collectFieldDescriptions(array $fields, string $prefix = ''): array
+    {
+        $descriptions = [];
+
+        foreach ($fields as $field) {
+            $name = $prefix !== '' ? "{$prefix}.{$field->name}" : $field->name;
+
+            if ($field instanceof Object_) {
+                $descriptions = [
+                    ...$descriptions,
+                    ...$this->collectFieldDescriptions(
+                        $field->getProperties()->toArray(),
+                        $name
+                    ),
+                ];
+
+                continue;
+            }
+
+            $desc = $this->describeField($field, $name);
+
+            if ($desc !== null) {
+                $descriptions[] = $desc;
+            }
+        }
+
+        return $descriptions;
+    }
+
+    private function describeField(Type $field, string $name): ?string
+    {
+        $type = $this->fieldTypeName($field);
+
+        if ($type === null) {
+            return null;
+        }
+
+        $capabilities = $this->fieldCapabilities($field);
+        $filter = $this->filterExample($field, $name);
+
+        $tags = $capabilities !== [] ? ' (' . implode(', ', $capabilities) . ')' : '';
+
+        if ($field instanceof Nested) {
+            return $this->describeNested($field, $name, $tags);
+        }
+
+        return "- {$name} [{$type}]{$tags}: {$filter}";
+    }
+
+    private function describeNested(Nested $field, string $name, string $tags): string
+    {
+        $subFields = array_filter(array_map(
+            fn (Type $child) => $this->describeField($child, $child->name),
+            $field->getProperties()->toArray()
+        ));
+
+        $desc = "- {$name} [nested]{$tags}: {$name}:{subfield:'value' AND other>10}";
+
+        if ($subFields !== []) {
+            $desc .= "\n  Sub-fields:\n" . implode("\n", array_map(
+                fn (string $line) => "  {$line}",
+                $subFields
+            ));
+        }
+
+        return $desc;
+    }
+
+    private function fieldTypeName(Type $field): ?string
+    {
+        return match (true) {
+            $field instanceof Keyword,
+            $field instanceof CaseSensitiveKeyword => 'keyword',
+            $field instanceof Number,
+            $field instanceof Price => 'number',
+            $field instanceof Boolean => 'boolean',
+            $field instanceof Date,
+            $field instanceof DateTime => 'date',
+            $field instanceof GeoPoint => 'geo',
+            $field instanceof Range => 'range',
+            $field instanceof Nested => 'nested',
+            $field instanceof Text => 'text',
+            default => null,
+        };
+    }
+
+    private function fieldCapabilities(Type $field): array
+    {
+        $capabilities = [];
+
+        $isSortable = match (true) {
+            $field instanceof Text => $field->isSortable(),
+            $field instanceof Nested, $field instanceof Range => false,
+            default => true,
+        };
+
+        if ($isSortable) {
+            $capabilities[] = 'sortable';
+        }
+
+        if ($field->isFacetable()) {
+            $capabilities[] = 'facetable';
+        }
+
+        return $capabilities;
+    }
+
+    private function filterExample(Type $field, string $name): string
+    {
+        return match (true) {
+            $field instanceof Keyword,
+            $field instanceof CaseSensitiveKeyword => "{$name}:'value' {$name}:['a','b'] {$name}:val*",
+            $field instanceof Number,
+            $field instanceof Price => "{$name}>n {$name}<=n {$name}:min..max",
+            $field instanceof Boolean => "{$name}:true {$name}:false",
+            $field instanceof Date,
+            $field instanceof DateTime => "{$name}>'2024-01-01' {$name}<'2024-12-31'",
+            $field instanceof GeoPoint => "{$name}:10km[lat,lon]",
+            $field instanceof Range => "{$name}>n {$name}:min..max",
+            $field instanceof Text => $field->isFilterable()
+                ? "{$name}:'value' {$name}:['a','b']"
+                : 'query only',
+            default => '',
+        };
+    }
+}

--- a/tests/SigmieIndexToolTest.php
+++ b/tests/SigmieIndexToolTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sigmie\Tests;
 
-require_once __DIR__ . '/Stubs/LaravelAiStubs.php';
+require_once __DIR__.'/Stubs/LaravelAiStubs.php';
 
 use Laravel\Ai\Tools\Request;
 use Sigmie\AI\AsTool;
@@ -17,7 +17,7 @@ use Sigmie\Testing\TestCase;
 
 class SigmieIndexToolTest extends TestCase
 {
-    private function createProductIndex(array $extraSetup = []): SigmieIndex
+    private function createProductIndex(): SigmieIndex
     {
         $index = new class($this->sigmie) extends SigmieIndex
         {
@@ -49,7 +49,6 @@ class SigmieIndexToolTest extends TestCase
                 return $props;
             }
         };
-
         $index->create();
 
         return $index;
@@ -193,7 +192,7 @@ class SigmieIndexToolTest extends TestCase
             {
                 $props = new NewProperties;
                 $props->name('name');
-                $props->nested('variants', function (NewProperties $p) {
+                $props->nested('variants', function (NewProperties $p): void {
                     $p->keyword('color');
                     $p->number('size');
                 });
@@ -238,7 +237,7 @@ class SigmieIndexToolTest extends TestCase
             public function properties(): NewProperties
             {
                 $props = new NewProperties;
-                $props->object('meta', function (NewProperties $p) {
+                $props->object('meta', function (NewProperties $p): void {
                     $p->keyword('author');
                 });
 
@@ -387,7 +386,7 @@ class SigmieIndexToolTest extends TestCase
         $documents = [];
         for ($i = 1; $i <= 5; $i++) {
             $documents[] = new Document([
-                'name' => "Product {$i}",
+                'name' => 'Product '.$i,
                 'brand' => 'Brand',
                 'price' => $i * 100,
                 'in_stock' => true,

--- a/tests/SigmieIndexToolTest.php
+++ b/tests/SigmieIndexToolTest.php
@@ -43,7 +43,7 @@ class SigmieIndexToolTest extends TestCase
                 $props->name('name');
                 $props->category('brand');
                 $props->number('price');
-                $props->boolean('in_stock');
+                $props->bool('in_stock');
                 $props->date('created_at');
 
                 return $props;

--- a/tests/SigmieIndexToolTest.php
+++ b/tests/SigmieIndexToolTest.php
@@ -1,0 +1,567 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\Tests;
+
+require_once __DIR__ . '/Stubs/LaravelAiStubs.php';
+
+use Laravel\Ai\Tools\Request;
+use Sigmie\AI\AsTool;
+use Sigmie\AI\SigmieIndexTool;
+use Sigmie\Document\Document;
+use Sigmie\Mappings\NewProperties;
+use Sigmie\Sigmie;
+use Sigmie\SigmieIndex;
+use Sigmie\Testing\TestCase;
+
+class SigmieIndexToolTest extends TestCase
+{
+    private function createProductIndex(array $extraSetup = []): SigmieIndex
+    {
+        $index = new class($this->sigmie) extends SigmieIndex
+        {
+            use AsTool;
+
+            protected string $indexName;
+
+            public function __construct(Sigmie $sigmie)
+            {
+                parent::__construct($sigmie);
+
+                $this->indexName = uniqid();
+            }
+
+            public function name(): string
+            {
+                return $this->indexName;
+            }
+
+            public function properties(): NewProperties
+            {
+                $props = new NewProperties;
+                $props->name('name');
+                $props->category('brand');
+                $props->number('price');
+                $props->boolean('in_stock');
+                $props->date('created_at');
+
+                return $props;
+            }
+        };
+
+        $index->create();
+
+        return $index;
+    }
+
+    /**
+     * @test
+     */
+    public function description_contains_index_name(): void
+    {
+        $index = $this->createProductIndex();
+
+        $tool = new SigmieIndexTool($index);
+
+        $this->assertStringContainsString($index->name(), $tool->description());
+    }
+
+    /**
+     * @test
+     */
+    public function description_contains_all_field_names(): void
+    {
+        $index = $this->createProductIndex();
+
+        $tool = new SigmieIndexTool($index);
+        $description = $tool->description();
+
+        $this->assertStringContainsString('name', $description);
+        $this->assertStringContainsString('brand', $description);
+        $this->assertStringContainsString('price', $description);
+        $this->assertStringContainsString('in_stock', $description);
+        $this->assertStringContainsString('created_at', $description);
+    }
+
+    /**
+     * @test
+     */
+    public function description_contains_field_types(): void
+    {
+        $index = $this->createProductIndex();
+
+        $tool = new SigmieIndexTool($index);
+        $description = $tool->description();
+
+        $this->assertStringContainsString('[text]', $description);
+        $this->assertStringContainsString('[number]', $description);
+        $this->assertStringContainsString('[boolean]', $description);
+        $this->assertStringContainsString('[date]', $description);
+    }
+
+    /**
+     * @test
+     */
+    public function description_contains_filter_examples(): void
+    {
+        $index = $this->createProductIndex();
+
+        $tool = new SigmieIndexTool($index);
+        $description = $tool->description();
+
+        // Keyword filter syntax
+        $this->assertStringContainsString("brand:'value'", $description);
+        $this->assertStringContainsString("brand:['a','b']", $description);
+
+        // Number filter syntax
+        $this->assertStringContainsString('price>n', $description);
+        $this->assertStringContainsString('price:min..max', $description);
+
+        // Boolean filter syntax
+        $this->assertStringContainsString('in_stock:true', $description);
+        $this->assertStringContainsString('in_stock:false', $description);
+
+        // Date filter syntax
+        $this->assertStringContainsString("created_at>'2024-01-01'", $description);
+    }
+
+    /**
+     * @test
+     */
+    public function description_contains_operator_docs(): void
+    {
+        $index = $this->createProductIndex();
+
+        $tool = new SigmieIndexTool($index);
+        $description = $tool->description();
+
+        $this->assertStringContainsString('AND, OR, AND NOT', $description);
+        $this->assertStringContainsString('NOT', $description);
+        $this->assertStringContainsString('Grouping', $description);
+        $this->assertStringContainsString('field:*', $description);
+    }
+
+    /**
+     * @test
+     */
+    public function description_shows_sortable_capability(): void
+    {
+        $index = $this->createProductIndex();
+
+        $tool = new SigmieIndexTool($index);
+        $description = $tool->description();
+
+        $this->assertStringContainsString('sortable', $description);
+    }
+
+    /**
+     * @test
+     */
+    public function description_shows_facetable_capability(): void
+    {
+        $index = $this->createProductIndex();
+
+        $tool = new SigmieIndexTool($index);
+        $description = $tool->description();
+
+        $this->assertStringContainsString('facetable', $description);
+    }
+
+    /**
+     * @test
+     */
+    public function description_handles_nested_fields(): void
+    {
+        $index = new class($this->sigmie) extends SigmieIndex
+        {
+            protected string $indexName;
+
+            public function __construct(Sigmie $sigmie)
+            {
+                parent::__construct($sigmie);
+
+                $this->indexName = uniqid();
+            }
+
+            public function name(): string
+            {
+                return $this->indexName;
+            }
+
+            public function properties(): NewProperties
+            {
+                $props = new NewProperties;
+                $props->name('name');
+                $props->nested('variants', function (NewProperties $p) {
+                    $p->keyword('color');
+                    $p->number('size');
+                });
+
+                return $props;
+            }
+        };
+
+        $index->create();
+
+        $tool = new SigmieIndexTool($index);
+        $description = $tool->description();
+
+        $this->assertStringContainsString('[nested]', $description);
+        $this->assertStringContainsString('variants:', $description);
+        $this->assertStringContainsString('Sub-fields', $description);
+        $this->assertStringContainsString('color', $description);
+        $this->assertStringContainsString('size', $description);
+    }
+
+    /**
+     * @test
+     */
+    public function description_handles_object_fields_with_dot_notation(): void
+    {
+        $index = new class($this->sigmie) extends SigmieIndex
+        {
+            protected string $indexName;
+
+            public function __construct(Sigmie $sigmie)
+            {
+                parent::__construct($sigmie);
+
+                $this->indexName = uniqid();
+            }
+
+            public function name(): string
+            {
+                return $this->indexName;
+            }
+
+            public function properties(): NewProperties
+            {
+                $props = new NewProperties;
+                $props->object('meta', function (NewProperties $p) {
+                    $p->keyword('author');
+                });
+
+                return $props;
+            }
+        };
+
+        $index->create();
+
+        $tool = new SigmieIndexTool($index);
+        $description = $tool->description();
+
+        $this->assertStringContainsString('meta.author', $description);
+    }
+
+    /**
+     * @test
+     */
+    public function handle_searches_and_returns_hits(): void
+    {
+        $index = $this->createProductIndex();
+
+        $index->merge([
+            new Document(['name' => 'iPhone', 'brand' => 'Apple', 'price' => 999, 'in_stock' => true, 'created_at' => '2024-01-15']),
+            new Document(['name' => 'Galaxy', 'brand' => 'Samsung', 'price' => 899, 'in_stock' => true, 'created_at' => '2024-02-20']),
+            new Document(['name' => 'Pixel', 'brand' => 'Google', 'price' => 699, 'in_stock' => false, 'created_at' => '2024-03-10']),
+        ], refresh: true);
+
+        $tool = new SigmieIndexTool($index);
+
+        $result = json_decode($tool->handle(new Request([
+            'query' => 'iPhone',
+        ])), true);
+
+        $this->assertArrayHasKey('total', $result);
+        $this->assertArrayHasKey('hits', $result);
+        $this->assertGreaterThan(0, $result['total']);
+        $this->assertEquals('iPhone', $result['hits'][0]['name']);
+    }
+
+    /**
+     * @test
+     */
+    public function handle_applies_filters(): void
+    {
+        $index = $this->createProductIndex();
+
+        $index->merge([
+            new Document(['name' => 'iPhone', 'brand' => 'Apple', 'price' => 999, 'in_stock' => true, 'created_at' => '2024-01-15']),
+            new Document(['name' => 'MacBook', 'brand' => 'Apple', 'price' => 1999, 'in_stock' => true, 'created_at' => '2024-02-20']),
+            new Document(['name' => 'Galaxy', 'brand' => 'Samsung', 'price' => 899, 'in_stock' => true, 'created_at' => '2024-03-10']),
+        ], refresh: true);
+
+        $tool = new SigmieIndexTool($index);
+
+        $result = json_decode($tool->handle(new Request([
+            'query' => '',
+            'filters' => "brand:'Apple'",
+        ])), true);
+
+        $this->assertEquals(2, $result['total']);
+
+        foreach ($result['hits'] as $hit) {
+            $this->assertEquals('Apple', $hit['brand']);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function handle_applies_base_filters(): void
+    {
+        $index = $this->createProductIndex();
+
+        $index->merge([
+            new Document(['name' => 'iPhone', 'brand' => 'Apple', 'price' => 999, 'in_stock' => true, 'created_at' => '2024-01-15']),
+            new Document(['name' => 'Galaxy', 'brand' => 'Samsung', 'price' => 899, 'in_stock' => true, 'created_at' => '2024-03-10']),
+            new Document(['name' => 'Pixel', 'brand' => 'Google', 'price' => 699, 'in_stock' => false, 'created_at' => '2024-03-10']),
+        ], refresh: true);
+
+        $tool = new SigmieIndexTool($index, baseFilters: "brand:'Apple'");
+
+        $result = json_decode($tool->handle(new Request([
+            'query' => '',
+        ])), true);
+
+        $this->assertEquals(1, $result['total']);
+        $this->assertEquals('Apple', $result['hits'][0]['brand']);
+    }
+
+    /**
+     * @test
+     */
+    public function handle_combines_base_filters_with_ai_filters(): void
+    {
+        $index = $this->createProductIndex();
+
+        $index->merge([
+            new Document(['name' => 'iPhone', 'brand' => 'Apple', 'price' => 999, 'in_stock' => true, 'created_at' => '2024-01-15']),
+            new Document(['name' => 'MacBook', 'brand' => 'Apple', 'price' => 1999, 'in_stock' => false, 'created_at' => '2024-02-20']),
+            new Document(['name' => 'Galaxy', 'brand' => 'Samsung', 'price' => 899, 'in_stock' => true, 'created_at' => '2024-03-10']),
+        ], refresh: true);
+
+        $tool = new SigmieIndexTool($index, baseFilters: "brand:'Apple'");
+
+        $result = json_decode($tool->handle(new Request([
+            'query' => '',
+            'filters' => 'in_stock:true',
+        ])), true);
+
+        $this->assertEquals(1, $result['total']);
+        $this->assertEquals('iPhone', $result['hits'][0]['name']);
+    }
+
+    /**
+     * @test
+     */
+    public function handle_applies_sort(): void
+    {
+        $index = $this->createProductIndex();
+
+        $index->merge([
+            new Document(['name' => 'iPhone', 'brand' => 'Apple', 'price' => 999, 'in_stock' => true, 'created_at' => '2024-01-15']),
+            new Document(['name' => 'Galaxy', 'brand' => 'Samsung', 'price' => 899, 'in_stock' => true, 'created_at' => '2024-03-10']),
+            new Document(['name' => 'Pixel', 'brand' => 'Google', 'price' => 699, 'in_stock' => true, 'created_at' => '2024-02-20']),
+        ], refresh: true);
+
+        $tool = new SigmieIndexTool($index);
+
+        $result = json_decode($tool->handle(new Request([
+            'query' => '',
+            'sort' => 'price:asc',
+        ])), true);
+
+        $this->assertEquals(699, $result['hits'][0]['price']);
+        $this->assertEquals(999, $result['hits'][2]['price']);
+    }
+
+    /**
+     * @test
+     */
+    public function handle_paginates_results(): void
+    {
+        $index = $this->createProductIndex();
+
+        $documents = [];
+        for ($i = 1; $i <= 5; $i++) {
+            $documents[] = new Document([
+                'name' => "Product {$i}",
+                'brand' => 'Brand',
+                'price' => $i * 100,
+                'in_stock' => true,
+                'created_at' => '2024-01-01',
+            ]);
+        }
+
+        $index->merge($documents, refresh: true);
+
+        $tool = new SigmieIndexTool($index);
+
+        $result = json_decode($tool->handle(new Request([
+            'query' => '',
+            'per_page' => 2,
+            'page' => 1,
+        ])), true);
+
+        $this->assertEquals(5, $result['total']);
+        $this->assertCount(2, $result['hits']);
+    }
+
+    /**
+     * @test
+     */
+    public function handle_returns_facets_when_requested(): void
+    {
+        $index = $this->createProductIndex();
+
+        $index->merge([
+            new Document(['name' => 'iPhone', 'brand' => 'Apple', 'price' => 999, 'in_stock' => true, 'created_at' => '2024-01-15']),
+            new Document(['name' => 'MacBook', 'brand' => 'Apple', 'price' => 1999, 'in_stock' => true, 'created_at' => '2024-02-20']),
+            new Document(['name' => 'Galaxy', 'brand' => 'Samsung', 'price' => 899, 'in_stock' => true, 'created_at' => '2024-03-10']),
+        ], refresh: true);
+
+        $tool = new SigmieIndexTool($index);
+
+        $result = json_decode($tool->handle(new Request([
+            'query' => '',
+            'facets' => 'brand',
+        ])), true);
+
+        $this->assertArrayHasKey('facets', $result);
+        $this->assertArrayHasKey('brand', $result['facets']);
+    }
+
+    /**
+     * @test
+     */
+    public function handle_returns_no_facets_key_when_not_requested(): void
+    {
+        $index = $this->createProductIndex();
+
+        $index->merge([
+            new Document(['name' => 'iPhone', 'brand' => 'Apple', 'price' => 999, 'in_stock' => true, 'created_at' => '2024-01-15']),
+        ], refresh: true);
+
+        $tool = new SigmieIndexTool($index);
+
+        $result = json_decode($tool->handle(new Request([
+            'query' => '',
+        ])), true);
+
+        $this->assertArrayNotHasKey('facets', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function hits_contain_id_and_source_fields(): void
+    {
+        $index = $this->createProductIndex();
+
+        $index->merge([
+            new Document(['name' => 'iPhone', 'brand' => 'Apple', 'price' => 999, 'in_stock' => true, 'created_at' => '2024-01-15']),
+        ], refresh: true);
+
+        $tool = new SigmieIndexTool($index);
+
+        $result = json_decode($tool->handle(new Request([
+            'query' => '',
+        ])), true);
+
+        $hit = $result['hits'][0];
+
+        $this->assertArrayHasKey('_id', $hit);
+        $this->assertArrayHasKey('name', $hit);
+        $this->assertArrayHasKey('brand', $hit);
+        $this->assertArrayHasKey('price', $hit);
+    }
+
+    /**
+     * @test
+     */
+    public function as_tool_trait_returns_sigmie_index_tool(): void
+    {
+        $index = $this->createProductIndex();
+
+        $tool = $index->toTool();
+
+        $this->assertInstanceOf(SigmieIndexTool::class, $tool);
+    }
+
+    /**
+     * @test
+     */
+    public function as_tool_trait_passes_base_filters(): void
+    {
+        $index = $this->createProductIndex();
+
+        $index->merge([
+            new Document(['name' => 'iPhone', 'brand' => 'Apple', 'price' => 999, 'in_stock' => true, 'created_at' => '2024-01-15']),
+            new Document(['name' => 'Galaxy', 'brand' => 'Samsung', 'price' => 899, 'in_stock' => true, 'created_at' => '2024-03-10']),
+        ], refresh: true);
+
+        $tool = $index->toTool(baseFilters: "brand:'Apple'");
+
+        $result = json_decode($tool->handle(new Request([
+            'query' => '',
+        ])), true);
+
+        $this->assertEquals(1, $result['total']);
+        $this->assertEquals('Apple', $result['hits'][0]['brand']);
+    }
+
+    /**
+     * @test
+     */
+    public function description_contains_facet_docs(): void
+    {
+        $index = $this->createProductIndex();
+
+        $tool = new SigmieIndexTool($index);
+        $description = $tool->description();
+
+        $this->assertStringContainsString('Facets', $description);
+        $this->assertStringContainsString('Sort', $description);
+        $this->assertStringContainsString('Geo sort', $description);
+    }
+
+    /**
+     * @test
+     */
+    public function description_marks_text_only_fields_as_query_only(): void
+    {
+        $index = new class($this->sigmie) extends SigmieIndex
+        {
+            protected string $indexName;
+
+            public function __construct(Sigmie $sigmie)
+            {
+                parent::__construct($sigmie);
+
+                $this->indexName = uniqid();
+            }
+
+            public function name(): string
+            {
+                return $this->indexName;
+            }
+
+            public function properties(): NewProperties
+            {
+                $props = new NewProperties;
+                $props->longText('body');
+
+                return $props;
+            }
+        };
+
+        $index->create();
+
+        $tool = new SigmieIndexTool($index);
+        $description = $tool->description();
+
+        $this->assertStringContainsString('query only', $description);
+    }
+}

--- a/tests/Stubs/LaravelAiStubs.php
+++ b/tests/Stubs/LaravelAiStubs.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Minimal stubs for Laravel AI SDK interfaces/classes.
+ * Loaded only when laravel/ai is not installed, so SigmieIndexTool can be tested.
+ */
+
+namespace Illuminate\Contracts\JsonSchema {
+    if (! interface_exists(JsonSchema::class)) {
+        interface JsonSchema
+        {
+            public function string(): mixed;
+
+            public function integer(): mixed;
+        }
+    }
+}
+
+namespace Laravel\Ai\Contracts {
+    if (! interface_exists(Tool::class)) {
+        interface Tool
+        {
+            public function description(): \Stringable|string;
+
+            public function handle(\Laravel\Ai\Tools\Request $request): \Stringable|string;
+
+            public function schema(\Illuminate\Contracts\JsonSchema\JsonSchema $schema): array;
+        }
+    }
+}
+
+namespace Laravel\Ai\Tools {
+    if (! class_exists(Request::class)) {
+        class Request implements \ArrayAccess
+        {
+            public function __construct(protected array $arguments = []) {}
+
+            public function string(string $key, string $default = ''): string
+            {
+                return (string) ($this->arguments[$key] ?? $default);
+            }
+
+            public function integer(string $key, int $default = 0): int
+            {
+                return (int) ($this->arguments[$key] ?? $default);
+            }
+
+            public function offsetExists(mixed $offset): bool
+            {
+                return isset($this->arguments[$offset]);
+            }
+
+            public function offsetGet(mixed $offset): mixed
+            {
+                return $this->arguments[$offset] ?? null;
+            }
+
+            public function offsetSet(mixed $offset, mixed $value): void
+            {
+                $this->arguments[$offset] = $value;
+            }
+
+            public function offsetUnset(mixed $offset): void
+            {
+                unset($this->arguments[$offset]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **`SigmieIndexTool`** — wraps any `SigmieIndex` as a `Laravel\Ai\Contracts\Tool` with auto-generated description from index properties, search/filter/sort/facet support, and `baseFilters` for multi-tenancy
- **`AsTool` trait** — adds `toTool()` shortcut to any `SigmieIndex` class
- **Documentation** — new `docs/laravel-ai.md` covering usage, filter syntax per field type, sorting, facets, and base filters

Usage:
```php
// Direct
new SigmieIndexTool(app(ProductIndex::class))
new SigmieIndexTool(app(OrderIndex::class), baseFilters: "user_id:{$user->id}")

// Via trait
app(ProductIndex::class)->toTool(baseFilters: "user_id:{$user->id}")
```

No hard dependency on `laravel/ai` — classes only load when used.

## Test plan

- [ ] Verify `SigmieIndexTool` generates correct description from various property types (text, keyword, number, boolean, date, geo, nested, object)
- [ ] Verify `handle()` executes search with query, filters, sort, facets, pagination
- [ ] Verify `baseFilters` are AND'd with AI filters with correct parentheses grouping
- [ ] Verify `AsTool` trait's `toTool()` returns configured `SigmieIndexTool`
- [ ] Verify no errors when `laravel/ai` is not installed (classes not referenced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)