### PR TITLE
fix: make SigmieIndexTool query cast rector-safe

### DIFF
--- a/src/AI/SigmieIndexTool.php
+++ b/src/AI/SigmieIndexTool.php
@@ -84,7 +84,7 @@ class SigmieIndexTool implements Tool
     public function handle(Request $request): string
     {
         $search = $this->index->newSearch()
-            ->queryString($request->string('query'))
+            ->queryString((string) ($request['query'] ?? ''))
             ->page(
                 $request->integer('page', 1),
                 $request->integer('per_page', 10),


### PR DESCRIPTION
## Problem

#63 fixed `SigmieIndexTool::handle()` by casting the query to `string` (so `NewSearch::queryString()` doesn't receive the `Stringable` that `Request::string()` returns). But the follow-up `chore: apply rector and pint fixes` commit on that branch **stripped the `(string)` cast as redundant**, so `master` reintroduced the `TypeError` — every `$index->toTool()` search call is broken again.

## Fix

Read the query via array access — `(string) ($request['query'] ?? '')` — exactly like the sibling `sort` / `facets` handling already in this method. The value is `mixed`, so Rector does not treat the cast as redundant.

## Verified

- `vendor/bin/rector process … --dry-run` → `[OK] Rector is done!` with **no** proposed change to the file (the cast survives).
- `vendor/bin/pint` → PASS.
- A realtime-voice tool dispatch through `OnboardingKnowledgeIndex->toTool()` returns ranked hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)