### PR TITLE
feat: field descriptions + value-discovery hint in SigmieIndexTool

### DIFF
--- a/src/AI/SigmieIndexTool.php
+++ b/src/AI/SigmieIndexTool.php
@@ -65,7 +65,8 @@ class SigmieIndexTool implements Tool
             ."Exists check: field:*\n"
             ."Sort: field:asc field:desc _score (space-separated)\n"
             ."Geo sort: field[lat,lon]:km:asc\n"
-            .'Facets: field1 field2:20 (space-separated, optional :size for keywords or :interval for numbers)');
+            ."Facets: field1 field2:20 (space-separated, optional :size for keywords or :interval for numbers)\n"
+            .'Discovering valid values: to filter on a field whose values you do not know, first search with that field name in `facets` (optionally narrowed by `query` or another filter), then read the returned facet values and filter by one of them.');
     }
 
     public function schema(JsonSchema $schema): array
@@ -180,7 +181,13 @@ class SigmieIndexTool implements Tool
             return $this->describeNested($field, $name, $tags);
         }
 
-        return sprintf('- %s [%s]%s: %s', $name, $type, $tags, $filter);
+        $line = sprintf('- %s [%s]%s: %s', $name, $type, $tags, $filter);
+
+        $description = $field->getMeta()['description'] ?? null;
+
+        return is_string($description) && $description !== ''
+            ? $line.' — '.$description
+            : $line;
     }
 
     private function describeNested(Nested $field, string $name, string $tags): string

--- a/src/Mappings/Types/Type.php
+++ b/src/Mappings/Types/Type.php
@@ -84,9 +84,16 @@ abstract class Type implements Name, TextQueries, ToRaw, TypeInterface
         return $this;
     }
 
-    public function meta(array $meta): void
+    public function meta(array $meta): static
     {
         $this->meta = [...$this->meta, ...$meta];
+
+        return $this;
+    }
+
+    public function getMeta(): array
+    {
+        return $this->meta;
     }
 
     public function isFacetable(): bool


### PR DESCRIPTION
## Why

When a Sigmie index is exposed to an agent via `AsTool`, the model only sees field **names + types + generic filter syntax** — no semantics and no valid values. It guesses wrong (e.g. filtering `country:'Germany'` when the real filter is `country_code_a3:'DEU'`).

## What

- **Field descriptions**: `describeField()` now appends a field's `meta(['description' => ...])` to its line, so an index can teach the model what a field means and which values are valid. `Type::meta()` is now fluent (`return static`) and gains `getMeta()`.
- **Value discovery for high-cardinality fields**: instead of enumerating thousands of values in the prompt, the tool description now tells the model to request a field in `facets` (optionally narrowed) to learn valid values, then filter by one. Uses the tool's existing facet support — no new endpoint.

Example annotation:

```php
$blueprint->keyword('country_code_a3')
    ->meta(['description' => 'Country as ISO-3166 alpha-3, e.g. DEU=Germany. Use for country filters, not `country`.']);
```

## Verified

`rector --dry-run` → `[OK]` (no reverts), `pint` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)