### PR TITLE
feat: ArrayResult — structured array accessor for index tools

### DIFF
--- a/src/AI/Contracts/ArrayResult.php
+++ b/src/AI/Contracts/ArrayResult.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\AI\Contracts;
+
+use Laravel\Ai\Tools\Request;
+
+/**
+ * A Laravel AI {@see \Laravel\Ai\Contracts\Tool} that can also expose its result as a structured
+ * array — for callers that want data rather than the JSON string handle() is required to return.
+ *
+ * Implementations should build the array in result() and have handle() serialise it, so the data
+ * is produced once and there's no encode → decode round-trip for consumers that want the array.
+ */
+interface ArrayResult
+{
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function result(Request $request): array;
+}

--- a/src/AI/SigmieFilterValuesTool.php
+++ b/src/AI/SigmieFilterValuesTool.php
@@ -7,6 +7,7 @@ namespace Sigmie\AI;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
+use Sigmie\AI\Contracts\ArrayResult;
 use Sigmie\SigmieIndex;
 
 /**
@@ -18,7 +19,7 @@ use Sigmie\SigmieIndex;
  * per-type parsing are handled by the search/facet layer; an unknown or non-facetable field
  * simply yields no values.
  */
-class SigmieFilterValuesTool implements Tool
+class SigmieFilterValuesTool implements ArrayResult, Tool
 {
     public function __construct(
         protected SigmieIndex $index,
@@ -51,6 +52,11 @@ class SigmieFilterValuesTool implements Tool
 
     public function handle(Request $request): string
     {
+        return json_encode($this->result($request), JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+    }
+
+    public function result(Request $request): array
+    {
         $fieldName = trim((string) ($request['field'] ?? ''));
         $limit = max(1, (int) ($request['limit'] ?? self::DEFAULT_LIMIT));
 
@@ -70,9 +76,9 @@ class SigmieFilterValuesTool implements Tool
 
         $facets = (array) ($search->get()->json('facets') ?? []);
 
-        return json_encode([
+        return [
             'field' => $fieldName,
             'values' => $facets[$fieldName] ?? null,
-        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+        ];
     }
 }

--- a/src/AI/SigmieIndexTool.php
+++ b/src/AI/SigmieIndexTool.php
@@ -7,6 +7,7 @@ namespace Sigmie\AI;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
+use Sigmie\AI\Contracts\ArrayResult;
 use Sigmie\Mappings\Types\Boolean;
 use Sigmie\Mappings\Types\CaseSensitiveKeyword;
 use Sigmie\Mappings\Types\Date;
@@ -39,7 +40,7 @@ use Sigmie\SigmieIndex;
  *       ];
  *   }
  */
-class SigmieIndexTool implements Tool
+class SigmieIndexTool implements ArrayResult, Tool
 {
     public function __construct(
         protected SigmieIndex $index,
@@ -83,6 +84,11 @@ class SigmieIndexTool implements Tool
     }
 
     public function handle(Request $request): string
+    {
+        return json_encode($this->result($request), JSON_PRETTY_PRINT);
+    }
+
+    public function result(Request $request): array
     {
         $search = $this->index->newSearch()
             ->queryString((string) ($request['query'] ?? ''))
@@ -132,7 +138,7 @@ class SigmieIndexTool implements Tool
             $result['facets'] = $response->json('facets');
         }
 
-        return json_encode($result, JSON_PRETTY_PRINT);
+        return $result;
     }
 
     private function collectFieldDescriptions(array $fields, string $prefix = ''): array

--- a/src/AI/SigmieSampleDocumentsTool.php
+++ b/src/AI/SigmieSampleDocumentsTool.php
@@ -7,15 +7,16 @@ namespace Sigmie\AI;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
+use Sigmie\AI\Contracts\ArrayResult;
 use Sigmie\SigmieIndex;
 
 /**
  * Companion to {@see SigmieIndexTool}: returns a few random example documents so an agent can see
  * the real data shape and field values before searching or filtering.
  *
- * Reuses the index's `collect()->random()` sampler and the collection's `toJson()`.
+ * Reuses the index's `collect()->random()` sampler; documents serialise via their JsonSerializable.
  */
-class SigmieSampleDocumentsTool implements Tool
+class SigmieSampleDocumentsTool implements ArrayResult, Tool
 {
     public function __construct(
         protected SigmieIndex $index,
@@ -43,8 +44,14 @@ class SigmieSampleDocumentsTool implements Tool
 
     public function handle(Request $request): string
     {
+        return json_encode($this->result($request), JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+    }
+
+    public function result(Request $request): array
+    {
         $limit = max(1, min(20, (int) ($request['limit'] ?? 5)));
 
-        return $this->index->collect()->random($limit)->toJson(JSON_UNESCAPED_UNICODE);
+        // Documents serialise to {_id, _source} via their JsonSerializable.
+        return $this->index->collect()->random($limit)->toArray();
     }
 }

--- a/tests/SigmieIndexToolTest.php
+++ b/tests/SigmieIndexToolTest.php
@@ -724,4 +724,40 @@ class SigmieIndexToolTest extends TestCase
         $this->assertArrayHasKey('_id', $result[0]);
         $this->assertArrayHasKey('_source', $result[0]);
     }
+
+    /**
+     * @test
+     */
+    public function tools_expose_array_results(): void
+    {
+        $index = $this->createProductIndex();
+
+        foreach ($index->tools() as $tool) {
+            $this->assertInstanceOf(\Sigmie\AI\Contracts\ArrayResult::class, $tool);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function result_returns_an_array_not_a_json_string(): void
+    {
+        $index = $this->createProductIndex();
+
+        $index->merge([
+            new Document(['name' => 'iPhone', 'brand' => 'Apple', 'price' => 999, 'in_stock' => true, 'created_at' => '2024-01-15']),
+        ], refresh: true);
+
+        $search = (new SigmieIndexTool($index))->result(new Request(['query' => '']));
+        $this->assertIsArray($search);
+        $this->assertArrayHasKey('total', $search);
+        $this->assertArrayHasKey('hits', $search);
+
+        $values = (new SigmieFilterValuesTool($index))->result(new Request(['field' => 'brand']));
+        $this->assertIsArray($values);
+        $this->assertArrayHasKey('values', $values);
+
+        $sample = (new SigmieSampleDocumentsTool($index))->result(new Request(['limit' => 1]));
+        $this->assertIsArray($sample);
+    }
 }

--- a/tests/SigmieIndexToolTest.php
+++ b/tests/SigmieIndexToolTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sigmie\Tests;
 
+use Sigmie\AI\Contracts\ArrayResult;
 use Sigmie\Base\ElasticsearchException;
 use Sigmie\Mappings\Types\Keyword;
 
@@ -733,7 +734,7 @@ class SigmieIndexToolTest extends TestCase
         $index = $this->createProductIndex();
 
         foreach ($index->tools() as $tool) {
-            $this->assertInstanceOf(\Sigmie\AI\Contracts\ArrayResult::class, $tool);
+            $this->assertInstanceOf(ArrayResult::class, $tool);
         }
     }
 


### PR DESCRIPTION
## Why

A Laravel AI `Tool::handle()` must return a **string** (the LLM tool result is text), so the index tools `json_encode(...)`. Consumers that want the data — e.g. an HTTP dispatcher exposing tool results to a frontend — then have to `json_decode` what was just encoded.

## What

- New `Sigmie\AI\Contracts\ArrayResult` with `result(Request $request): array`.
- `SigmieIndexTool`, `SigmieFilterValuesTool`, `SigmieSampleDocumentsTool` implement it: `result()` builds the structured array, `handle()` serialises it. `handle()` is unchanged in behaviour (still the JSON string for the LLM).
- Consumers can now call `result()` for the array directly — no encode→decode round-trip.

```php
$tool instanceof ArrayResult
    ? $tool->result($request)   // array
    : $tool->handle($request);  // string
```

## Tests

`SigmieIndexToolTest`: tools implement `ArrayResult`, and `result()` returns an array (not a JSON string). **32 passing, 83 assertions** (`SEARCH_ENGINE=elasticsearch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)