### PR TITLE
feat: result() array accessor on the index tools

### DIFF
--- a/src/AI/SigmieFilterValuesTool.php
+++ b/src/AI/SigmieFilterValuesTool.php
@@ -51,6 +51,14 @@ class SigmieFilterValuesTool implements Tool
 
     public function handle(Request $request): string
     {
+        return json_encode($this->result($request), JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+    }
+
+    /**
+     * The discovered values as an array, for callers that want data instead of the JSON string handle() returns.
+     */
+    public function result(Request $request): array
+    {
         $fieldName = trim((string) ($request['field'] ?? ''));
         $limit = max(1, (int) ($request['limit'] ?? self::DEFAULT_LIMIT));
 
@@ -70,9 +78,9 @@ class SigmieFilterValuesTool implements Tool
 
         $facets = (array) ($search->get()->json('facets') ?? []);
 
-        return json_encode([
+        return [
             'field' => $fieldName,
             'values' => $facets[$fieldName] ?? null,
-        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+        ];
     }
 }

--- a/src/AI/SigmieIndexTool.php
+++ b/src/AI/SigmieIndexTool.php
@@ -84,6 +84,14 @@ class SigmieIndexTool implements Tool
 
     public function handle(Request $request): string
     {
+        return json_encode($this->result($request), JSON_PRETTY_PRINT);
+    }
+
+    /**
+     * The search result as an array, for callers that want data instead of the JSON string handle() returns.
+     */
+    public function result(Request $request): array
+    {
         $search = $this->index->newSearch()
             ->queryString((string) ($request['query'] ?? ''))
             ->page(
@@ -132,7 +140,7 @@ class SigmieIndexTool implements Tool
             $result['facets'] = $response->json('facets');
         }
 
-        return json_encode($result, JSON_PRETTY_PRINT);
+        return $result;
     }
 
     private function collectFieldDescriptions(array $fields, string $prefix = ''): array

--- a/src/AI/SigmieSampleDocumentsTool.php
+++ b/src/AI/SigmieSampleDocumentsTool.php
@@ -43,8 +43,17 @@ class SigmieSampleDocumentsTool implements Tool
 
     public function handle(Request $request): string
     {
+        return json_encode($this->result($request), JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * The sample documents as an array, for callers that want data instead of the JSON string handle() returns.
+     */
+    public function result(Request $request): array
+    {
         $limit = max(1, min(20, (int) ($request['limit'] ?? 5)));
 
-        return $this->index->collect()->random($limit)->toJson(JSON_UNESCAPED_UNICODE);
+        // Documents serialise to {_id, _source} via their JsonSerializable.
+        return $this->index->collect()->random($limit)->toArray();
     }
 }

--- a/tests/SigmieIndexToolTest.php
+++ b/tests/SigmieIndexToolTest.php
@@ -724,4 +724,28 @@ class SigmieIndexToolTest extends TestCase
         $this->assertArrayHasKey('_id', $result[0]);
         $this->assertArrayHasKey('_source', $result[0]);
     }
+
+    /**
+     * @test
+     */
+    public function result_returns_an_array_not_a_json_string(): void
+    {
+        $index = $this->createProductIndex();
+
+        $index->merge([
+            new Document(['name' => 'iPhone', 'brand' => 'Apple', 'price' => 999, 'in_stock' => true, 'created_at' => '2024-01-15']),
+        ], refresh: true);
+
+        $search = (new SigmieIndexTool($index))->result(new Request(['query' => '']));
+        $this->assertIsArray($search);
+        $this->assertArrayHasKey('total', $search);
+        $this->assertArrayHasKey('hits', $search);
+
+        $values = (new SigmieFilterValuesTool($index))->result(new Request(['field' => 'brand']));
+        $this->assertIsArray($values);
+        $this->assertArrayHasKey('values', $values);
+
+        $sample = (new SigmieSampleDocumentsTool($index))->result(new Request(['limit' => 1]));
+        $this->assertIsArray($sample);
+    }
 }


### PR DESCRIPTION
## Why

A Laravel AI `Tool::handle()` must return a **string** (the LLM tool result is text), so the index tools `json_encode(...)`. An HTTP dispatcher that exposes tool results to a frontend then has to `json_decode` what was just encoded.

## What

Each tool — `SigmieIndexTool`, `SigmieFilterValuesTool`, `SigmieSampleDocumentsTool` — now has a public **`result(Request): array`** that builds the structured data; **`handle()` just serialises it**. No interface (per review feedback that one was overkill) — consumers duck-type:

```php
$out = method_exists($tool, 'result') ? $tool->result($req) : $tool->handle($req);
```

`handle()` behaviour is unchanged (same JSON string for the LLM).

## Tests

`SigmieIndexToolTest`: `result()` returns an array (with the expected keys) for all three tools. **31 passing, 80 assertions** (`SEARCH_ENGINE=elasticsearch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)