### PR TITLE
fix: throw ParseException on unbalanced parentheses in a filter

### DIFF
--- a/src/Parse/FilterParser.php
+++ b/src/Parse/FilterParser.php
@@ -92,6 +92,12 @@ class FilterParser extends Parser
             // match all parenthentic expresions recusively
             preg_match_all("/\(([^()]|(?R))*\)/", $query, $matches);
 
+            // No balanced parenthetic group means the expression is malformed (e.g. unbalanced
+            // parentheses). Surface a clear parse error instead of an out-of-bounds access.
+            if (! isset($matches[0][0])) {
+                throw new ParseException(sprintf("Invalid filter: unbalanced parentheses in '%s'.", $query));
+            }
+
             $matchWithParentheses = $matches[0][0];
 
             // Remove outer parenthesis

--- a/tests/FilterParserTest.php
+++ b/tests/FilterParserTest.php
@@ -2152,4 +2152,20 @@ class FilterParserTest extends TestCase
 
         $this->assertCount(2, $res->json('hits.hits'));
     }
+
+    /**
+     * @test
+     */
+    public function unbalanced_parentheses_throw_a_parse_exception(): void
+    {
+        $props = new NewProperties;
+        $props->keyword('color');
+
+        $parser = new FilterParser($props, false);
+
+        $this->expectException(ParseException::class);
+
+        // Unbalanced parentheses previously caused a raw "Undefined array key 0" PHP error.
+        $parser->parse('(color:bar');
+    }
 }


### PR DESCRIPTION
## Problem

A filter expression that starts with `(` but has no balanced parenthetic group — e.g. `(color:bar`, or `field:((` once the caller wraps it in parens → `(field:(()` which normalises to `(field:(` — made `FilterParser::parseString()` read `$matches[0][0]` out of bounds. The result was a raw **`Undefined array key 0`** PHP error rather than a parse error.

This matters when tool/agent layers surface filter errors back to an LLM: a cryptic `"Undefined array key 0"` gives the model nothing to act on, whereas a real parse error lets it correct the filter and retry.

## Fix

Guard the empty-match case and `throw new ParseException(...)` with a clear message — consistent with the other structural errors in this parser (nesting limit, invalid filter string, unmatched operator), which already throw `ParseException` directly.

```
Invalid filter: unbalanced parentheses in '(color:bar'.
```

## Tests

`FilterParserTest`: unbalanced parentheses now throw `ParseException`. Full suite green — **47 passing, 101 assertions** (`SEARCH_ENGINE=elasticsearch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)