### PR TITLE
fix: handle apostrophes inside quoted filter values

### DIFF
--- a/src/Parse/FilterParser.php
+++ b/src/Parse/FilterParser.php
@@ -22,6 +22,15 @@ use Sigmie\Query\Queries\Text\Nested;
 
 class FilterParser extends Parser
 {
+    // Placeholder bytes used to neutralize quote characters that live *inside*
+    // a quoted value (escaped quotes like \' or an apostrophe inside "..."),
+    // so the parser's quote-parity counting only ever sees the real delimiters.
+    private const ESC_SINGLE = "\x01";
+
+    private const ESC_DOUBLE = "\x02";
+
+    private const ESC_BACKSLASH = "\x03";
+
     protected ?string $parentPath = null;
 
     public static int $maxNestingLevel = 32;
@@ -160,9 +169,36 @@ class FilterParser extends Parser
             return $bool;
         }
 
-        $filters = $this->parseString($filterString);
+        $filters = $this->parseString($this->maskQuotedValues($filterString));
 
         return $this->apply($filters);
+    }
+
+    // Replace every quote character that appears *inside* a quoted value with a
+    // placeholder byte, leaving only the delimiting quotes in place. This keeps
+    // the parser's quote-parity logic correct even when a value contains an
+    // escaped quote (team:'O\'Brien') or an apostrophe inside double quotes
+    // (team:"O'Brien"). Values are restored via unmaskQuotedValue() on extraction.
+    protected function maskQuotedValues(string $filter): string
+    {
+        return preg_replace_callback(
+            '/(["\'])((?:\\\\.|(?!\1).)*)\1/s',
+            fn (array $m): string => $m[1].str_replace(
+                ['\\\\', "\\'", '\\"', "'", '"'],
+                [self::ESC_BACKSLASH, self::ESC_SINGLE, self::ESC_DOUBLE, self::ESC_SINGLE, self::ESC_DOUBLE],
+                $m[2]
+            ).$m[1],
+            $filter
+        );
+    }
+
+    protected function unmaskQuotedValue(string $value): string
+    {
+        return str_replace(
+            [self::ESC_SINGLE, self::ESC_DOUBLE, self::ESC_BACKSLASH],
+            ["'", '"', '\\'],
+            $value
+        );
     }
 
     protected function apply(string|array $filters, string $operator = 'AND'): Boolean
@@ -244,7 +280,7 @@ class FilterParser extends Parser
             return $bool;
         }
 
-        $filters = $this->parseString($filterString);
+        $filters = $this->parseString($this->maskQuotedValues($filterString));
 
         return $this->apply($filters);
     }
@@ -370,7 +406,7 @@ class FilterParser extends Parser
 
         $field = $matches[1];
         $operator = $matches[2];
-        $value = trim($matches[3], '"\'');
+        $value = $this->unmaskQuotedValue(trim($matches[3], '"\''));
 
         $realFieldName = $this->handleFieldName($field);
         if (is_null($realFieldName)) {
@@ -399,6 +435,7 @@ class FilterParser extends Parser
         $values = array_map(fn ($value): string => trim($value, ' '), $values);
         $values = array_map(fn ($value): string => trim($value, "'"), $values);
         $values = array_map(fn ($value): string => trim($value, '"'), $values);
+        $values = array_map(fn ($value): string => $this->unmaskQuotedValue($value), $values);
 
         return new IDs($values);
     }
@@ -459,6 +496,8 @@ class FilterParser extends Parser
         $values = array_map(fn ($value): string => trim($value, "'"), $values);
         // Remove single quotes from values
         $values = array_map(fn ($value): string => trim($value, '"'), $values);
+        // Restore any quote characters that lived inside the values
+        $values = array_map(fn ($value): string => $this->unmaskQuotedValue($value), $values);
 
         $realFieldName = $this->handleFieldName($field);
 
@@ -489,6 +528,8 @@ class FilterParser extends Parser
         $value = trim($value, "'");
         // Remove quotes from value
         $value = trim($value, '"');
+        // Restore any quote characters that lived inside the value
+        $value = $this->unmaskQuotedValue($value);
 
         $realFieldName = $this->handleFieldName($field);
 
@@ -507,6 +548,8 @@ class FilterParser extends Parser
         $value = trim($value, "'");
         // Remove quotes from value
         $value = trim($value, '"');
+        // Restore any quote characters that lived inside the value
+        $value = $this->unmaskQuotedValue($value);
 
         $realFieldName = $this->handleFieldName($field);
 

--- a/tests/FilterParserTest.php
+++ b/tests/FilterParserTest.php
@@ -59,6 +59,51 @@ class FilterParserTest extends TestCase
     /**
      * @test
      */
+    public function apostrophe_in_value(): void
+    {
+        $indexName = uniqid();
+
+        $props = new NewProperties;
+        $props->keyword('team_id');
+        $props->keyword('company');
+
+        $index = $this->sigmie->newIndex($indexName)
+            ->properties($props)
+            ->create();
+
+        $index = $this->sigmie->collect($indexName, true);
+
+        $docs = [
+            new Document([
+                'team_id' => '1',
+                'company' => "O'Brien GmbH",
+            ]),
+            new Document([
+                'team_id' => '1',
+                'company' => 'Acme',
+            ]),
+        ];
+
+        $index->merge($docs);
+
+        $parser = new FilterParser($props, false);
+
+        // Escaped apostrophe inside single quotes
+        $query = $parser->parse("team_id:'1' AND company:'O\\'Brien GmbH'");
+        $res = $this->sigmie->query($indexName, $query)->get();
+        $this->assertCount(1, $res->json('hits.hits'));
+        $this->assertSame("O'Brien GmbH", $res->json('hits.hits.0._source.company'));
+
+        // Apostrophe inside double quotes
+        $query = $parser->parse('team_id:\'1\' AND company:"O\'Brien GmbH"');
+        $res = $this->sigmie->query($indexName, $query)->get();
+        $this->assertCount(1, $res->json('hits.hits'));
+        $this->assertSame("O'Brien GmbH", $res->json('hits.hits.0._source.company'));
+    }
+
+    /**
+     * @test
+     */
     public function end_in_query(): void
     {
         $indexName = uniqid();


### PR DESCRIPTION
## What was broken

Filter strings with an apostrophe in the value failed as soon as they were combined with `AND`/`OR`:

```
team_id:'1' AND company:'O\'Brien GmbH'   ❌ ParseException: Invalid filter string
team_id:'1' AND company:"O'Brien GmbH"    ❌ ParseException: Invalid filter string
```

A *single* clause sometimes survived, but any multi-clause filter (the real-world case) blew up.

## Why it happened

The parser doesn't tokenize — it decides "is this `AND` inside a quote?" by **counting quote characters** with regex parity look‑aheads (`FilterParser.php` split at the old line 116, plus the whitespace/paren handlers). The rule is: *split only if there's an even number of quote chars after this point.*

That count is blind to escaping and to quote type. An escaped quote `\'`, or an apostrophe sitting inside `"..."`, is counted as a real delimiter — which flips the parity to **odd**:

```
team_id:'1' AND company:'O\'Brien GmbH'
        ^ ^        ^  ^             ^
        1 2        3  4             5     <- 5 quotes seen after AND  → ODD
                      └ the escaped \' is counted as a delimiter

ODD parity  →  parser thinks the AND is *inside* a quote  →  refuses to split
            →  whole string treated as one filter
            →  it contains a space  →  throw "Invalid filter string"
```

A merged-quote parity count fundamentally can't tell a delimiter from an embedded/escaped quote, so patching the individual look‑aheads wouldn't be enough.

## The fix

Before parsing, mask every quote character that lives *inside* a value with a placeholder byte, leaving only the real delimiters for the parity logic to count. Restore them when the value is extracted.

```
team_id:'1' AND company:'O\x01Brien GmbH'      (\' → placeholder)
        ^ ^        ^             ^
        1 2        3             4             <- 4 quotes → EVEN → splits cleanly
```

```
maskQuotedValues()   run once at parse() / facetFilter() entry
unmaskQuotedValue()  run in the value handlers (term, wildcard, range, in, ids)
```

This also fixes a second latent bug: escaped values used to keep their backslash
(`O\'Brien` instead of `O'Brien`), because `trim($value, "'")` never unescaped — the
mask/unmask round-trip now produces the correct `O'Brien`.

Wildcards (`*`), spaces, and even literal `AND`/`OR` words inside quotes are untouched — only the quote characters themselves are masked.

## Tests

- New `apostrophe_in_value` test indexes `O'Brien GmbH` and asserts both the escaped
  single-quote and the double-quote forms match it through a real Elasticsearch query.
- Full `FilterParserTest` suite stays green (48 tests).
