### PR TITLE
feat: surface tool errors to the agent instead of aborting the turn

### DIFF
--- a/src/AI/HandlesToolErrors.php
+++ b/src/AI/HandlesToolErrors.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\AI;
+
+use Throwable;
+
+/**
+ * Guards the agent-facing handle() of a tool so any failure — a filter/sort parse error, an
+ * unknown field, a query error — is returned to the model as a readable JSON {"error": ...}
+ * it can self-correct from, instead of throwing and aborting the whole agent turn.
+ *
+ * Only handle() is guarded. The structured result() methods still throw, so programmatic
+ * callers keep normal exception semantics.
+ */
+trait HandlesToolErrors
+{
+    /**
+     * @param  callable(): string  $work
+     */
+    protected function guard(callable $work): string
+    {
+        try {
+            return $work();
+        } catch (Throwable $e) {
+            return json_encode(
+                ['error' => $this->toolErrorMessage($e)],
+                JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+            );
+        }
+    }
+
+    protected function toolErrorMessage(Throwable $e): string
+    {
+        $reason = trim($e->getMessage());
+
+        // Elasticsearch errors often arrive as a JSON body — surface the human-readable reason.
+        $decoded = json_decode($reason, true);
+
+        if (is_array($decoded)) {
+            $reason = $decoded['error']['root_cause'][0]['reason']
+                ?? $decoded['error']['reason']
+                ?? $reason;
+        }
+
+        return $reason." Check the field names and the filter/sort syntax in this tool's description, then try again.";
+    }
+}

--- a/src/AI/HandlesToolErrors.php
+++ b/src/AI/HandlesToolErrors.php
@@ -23,9 +23,9 @@ trait HandlesToolErrors
     {
         try {
             return $work();
-        } catch (Throwable $e) {
+        } catch (Throwable $throwable) {
             return json_encode(
-                ['error' => $this->toolErrorMessage($e)],
+                ['error' => $this->toolErrorMessage($throwable)],
                 JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
             );
         }

--- a/src/AI/SigmieFilterValuesTool.php
+++ b/src/AI/SigmieFilterValuesTool.php
@@ -20,6 +20,8 @@ use Sigmie\SigmieIndex;
  */
 class SigmieFilterValuesTool implements Tool
 {
+    use HandlesToolErrors;
+
     public function __construct(
         protected SigmieIndex $index,
         protected string $baseFilters = '',
@@ -51,7 +53,7 @@ class SigmieFilterValuesTool implements Tool
 
     public function handle(Request $request): string
     {
-        return json_encode($this->result($request), JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+        return $this->guard(fn (): string => json_encode($this->result($request), JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE));
     }
 
     /**

--- a/src/AI/SigmieIndexTool.php
+++ b/src/AI/SigmieIndexTool.php
@@ -41,6 +41,8 @@ use Sigmie\SigmieIndex;
  */
 class SigmieIndexTool implements Tool
 {
+    use HandlesToolErrors;
+
     public function __construct(
         protected SigmieIndex $index,
         protected string $baseFilters = '',
@@ -84,7 +86,7 @@ class SigmieIndexTool implements Tool
 
     public function handle(Request $request): string
     {
-        return json_encode($this->result($request), JSON_PRETTY_PRINT);
+        return $this->guard(fn (): string => json_encode($this->result($request), JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR));
     }
 
     /**

--- a/src/AI/SigmieSampleDocumentsTool.php
+++ b/src/AI/SigmieSampleDocumentsTool.php
@@ -17,6 +17,8 @@ use Sigmie\SigmieIndex;
  */
 class SigmieSampleDocumentsTool implements Tool
 {
+    use HandlesToolErrors;
+
     public function __construct(
         protected SigmieIndex $index,
     ) {}
@@ -43,7 +45,7 @@ class SigmieSampleDocumentsTool implements Tool
 
     public function handle(Request $request): string
     {
-        return json_encode($this->result($request), JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+        return $this->guard(fn (): string => json_encode($this->result($request), JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR));
     }
 
     /**

--- a/tests/SigmieIndexToolTest.php
+++ b/tests/SigmieIndexToolTest.php
@@ -6,6 +6,7 @@ namespace Sigmie\Tests;
 
 use Sigmie\Base\ElasticsearchException;
 use Sigmie\Mappings\Types\Keyword;
+use Sigmie\Parse\ParseException;
 
 require_once __DIR__.'/Stubs/LaravelAiStubs.php';
 
@@ -695,15 +696,30 @@ class SigmieIndexToolTest extends TestCase
     /**
      * @test
      */
-    public function filter_values_errors_on_unknown_field(): void
+    public function filter_values_handle_surfaces_unknown_field_as_error(): void
     {
         $index = $this->createProductIndex();
 
-        // No client-side validation: an unknown/non-facetable field surfaces as an engine
-        // error, which the agent SDK / tool-call dispatch reports back to the model.
+        // handle() must NOT throw — an unknown/non-facetable field is returned as a readable
+        // {"error": ...} so the agent can read it and correct its arguments, instead of the
+        // whole turn aborting on an uncaught exception.
+        $result = json_decode((new SigmieFilterValuesTool($index))->handle(new Request(['field' => 'nope'])), true);
+
+        $this->assertArrayHasKey('error', $result);
+        $this->assertNotEmpty($result['error']);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_values_result_still_throws_on_unknown_field(): void
+    {
+        $index = $this->createProductIndex();
+
+        // result() keeps normal exception semantics for programmatic callers.
         $this->expectException(ElasticsearchException::class);
 
-        (new SigmieFilterValuesTool($index))->handle(new Request(['field' => 'nope']));
+        (new SigmieFilterValuesTool($index))->result(new Request(['field' => 'nope']));
     }
 
     /**
@@ -747,5 +763,56 @@ class SigmieIndexToolTest extends TestCase
 
         $sample = (new SigmieSampleDocumentsTool($index))->result(new Request(['limit' => 1]));
         $this->assertIsArray($sample);
+    }
+
+    /**
+     * @test
+     */
+    public function handle_surfaces_malformed_sort_as_error(): void
+    {
+        $index = $this->createProductIndex();
+
+        // SQL-style "price asc" (a space instead of "price:asc") makes the sort parser throw.
+        // handle() must return it as an {"error": ...} the agent can correct, not propagate
+        // an exception that aborts the turn.
+        $result = json_decode((new SigmieIndexTool($index))->handle(new Request([
+            'query' => '',
+            'sort' => 'price asc',
+        ])), true);
+
+        $this->assertArrayHasKey('error', $result);
+        $this->assertNotEmpty($result['error']);
+    }
+
+    /**
+     * @test
+     */
+    public function handle_surfaces_malformed_filter_as_error(): void
+    {
+        $index = $this->createProductIndex();
+
+        $result = json_decode((new SigmieIndexTool($index))->handle(new Request([
+            'query' => '',
+            'filters' => '(brand:',
+        ])), true);
+
+        $this->assertArrayHasKey('error', $result);
+        $this->assertNotEmpty($result['error']);
+    }
+
+    /**
+     * @test
+     */
+    public function result_still_throws_on_malformed_filter(): void
+    {
+        $index = $this->createProductIndex();
+
+        // result() keeps normal exception semantics; only handle() is guarded.
+        $this->expectException(ParseException::class);
+
+        (new SigmieIndexTool($index))->result(new Request([
+            'query' => '',
+            'filters' => '(brand:',
+        ]));
     }
 }


### PR DESCRIPTION
## Why

The AI tools' `handle()` let exceptions propagate — filter/sort **parse errors** (`ParseException: Field asc does not exist`), unknown/non-facetable fields (`ElasticsearchException`), and query errors. But the **Laravel AI SDK does not catch tool exceptions**: it aborts the whole agent turn, so the model never sees the error and cannot self-correct.

We confirmed this with a 20-turn agent eval against a live index: every time the model wrote a slightly-off query (e.g. SQL-style `monthly_price asc` instead of `monthly_price:asc`), the `ParseException` propagated out of `handle()` and killed the turn. When the same class of error *is* surfaced as a result, the model reads it and retries correctly.

Today only apps that wrap the tool themselves (e.g. a custom voice controller with try/catch) get self-correction. This moves that behavior into the tools, so **every** agent path — chat, voice, third-party — gets it for free.

## What

- New `HandlesToolErrors` trait: guards `handle()` so any `Throwable` is returned as `{"error": "<reason> Check the field names and the filter/sort syntax in this tool's description, then try again."}`. Elasticsearch JSON error bodies are unwrapped to their `root_cause.reason`.
- Applied to `SigmieIndexTool`, `SigmieFilterValuesTool`, `SigmieSampleDocumentsTool`.
- The structured `result()` methods are **unchanged** — they still throw, so programmatic callers keep normal exception semantics. Only the agent-facing `handle()` is guarded.

## Tests

`SigmieIndexToolTest` (35 passing, 87 assertions):
- `handle()` surfaces malformed **sort**, malformed **filter**, and **unknown field** as `{"error": ...}` (no throw).
- `result()` still throws `ParseException` / `ElasticsearchException` for the same inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)