### PR TITLE
feat: add filterQuery() to compose a hard query clause with the string filter

### DIFF
--- a/src/Search/NewSearch.php
+++ b/src/Search/NewSearch.php
@@ -82,6 +82,8 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
 
     protected int $collapseTop = 0;
 
+    protected array $filterQueries = [];
+
     public function __construct(
         ElasticsearchConnection $elasticsearchConnection
     ) {
@@ -177,6 +179,33 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
         $this->globalFilters = $this->filterParser->parse($this->searchContext->filterString);
 
         return $this;
+    }
+
+    public function filterQuery(Query $query): static
+    {
+        $this->filterQueries[] = $query;
+
+        return $this;
+    }
+
+    // Compose the parsed string filter with any raw queries added via
+    // filterQuery() as sibling clauses in a single filter context, so they
+    // are ANDed together without disturbing the parsed query's own
+    // should/must_not semantics (it stays nested as one clause).
+    protected function appliedFilters(): Boolean
+    {
+        if ($this->filterQueries === []) {
+            return $this->globalFilters;
+        }
+
+        $boolean = new Boolean;
+        $filter = $boolean->filter()->query($this->globalFilters);
+
+        foreach ($this->filterQueries as $query) {
+            $filter->query($query);
+        }
+
+        return $boolean;
     }
 
     public function textScoreMultiplier(float $multiplier = 1.0): static
@@ -331,7 +360,7 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
     {
         $boolean->must()->bool(
             fn (Boolean $boolean): BooleanQueryBuilder => $boolean->filter()->query(
-                $this->globalFilters
+                $this->appliedFilters()
             )
         );
     }
@@ -406,7 +435,7 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
         $facets = new Search($this->elasticsearchConnection);
 
         $facets->index($this->index)
-            ->query($this->globalFilters)
+            ->query($this->appliedFilters())
             ->aggs($this->facets);
 
         return $facets;
@@ -694,7 +723,7 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
             $vectorByDims = new Collection([$dims => $vector]);
 
             // Build queries for these fields
-            $vectorQueries = $this->buildVectorQueries($fields, $vectorByDims, $queryImage->weight(), $this->globalFilters);
+            $vectorQueries = $this->buildVectorQueries($fields, $vectorByDims, $queryImage->weight(), $this->appliedFilters());
 
             $vectorQueries->each(function (Query $query) use (&$knnQueries, &$semanticQueries): void {
 
@@ -783,7 +812,7 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
             $vectorByDims = new Collection([$dims => $vector]);
 
             // Build queries for these fields
-            $vectorQueries = $this->buildVectorQueries($fields, $vectorByDims, $queryString->weight(), $this->globalFilters);
+            $vectorQueries = $this->buildVectorQueries($fields, $vectorByDims, $queryString->weight(), $this->appliedFilters());
 
             $vectorQueries->each(function (Query $query) use (&$knnQueries, &$semanticQueries): void {
                 $raw = $query->toRaw();

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -1560,4 +1560,44 @@ class SearchTest extends TestCase
         $this->assertEquals(2, $res->total());
         $this->assertEquals(['Alice', 'Carol'], $names);
     }
+
+    /**
+     * @test
+     */
+    public function filter_query_constrains_facet_counts(): void
+    {
+        $indexName = uniqid();
+
+        $blueprint = new NewProperties;
+        $blueprint->name('name');
+        $blueprint->keyword('category');
+        $blueprint->bool('active');
+
+        $this->sigmie->newIndex($indexName)
+            ->properties($blueprint)
+            ->create();
+
+        $index = $this->sigmie->collect($indexName, refresh: true);
+
+        $index->merge([
+            new Document(['name' => 'Alice', 'category' => 'public', 'active' => true]),
+            new Document(['name' => 'Bob', 'category' => 'public', 'active' => false]),
+            new Document(['name' => 'Carol', 'category' => 'private', 'active' => true]),
+        ]);
+
+        // The hard clause lives in the query, so the facet aggregation is
+        // scoped by it too: the inactive 'public' document is not counted.
+        $res = $this->sigmie->newSearch($indexName)
+            ->properties($blueprint())
+            ->queryString('')
+            ->facets('category')
+            ->filterQuery(new Term('active', true))
+            ->get();
+
+        $props = $blueprint();
+
+        $facets = $props['category']->facets($res->facetAggregations());
+
+        $this->assertEquals(['private' => 1, 'public' => 1], $facets);
+    }
 }

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -12,6 +12,7 @@ use Sigmie\Languages\English\English;
 use Sigmie\Languages\German\German;
 use Sigmie\Mappings\NewProperties;
 use Sigmie\Query\Queries\Term\Range;
+use Sigmie\Query\Queries\Term\Term;
 use Sigmie\Testing\TestCase;
 
 class SearchTest extends TestCase
@@ -1508,5 +1509,55 @@ class SearchTest extends TestCase
             2,
             $groupA['inner_hits']['top']['hits']['hits']
         );
+    }
+
+    /**
+     * @test
+     */
+    public function filter_query_ands_a_hard_clause_with_the_string_filter(): void
+    {
+        $indexName = uniqid();
+
+        $blueprint = new NewProperties;
+        $blueprint->name('name');
+        $blueprint->keyword('category');
+        $blueprint->bool('active');
+
+        $this->sigmie->newIndex($indexName)
+            ->properties($blueprint)
+            ->create();
+
+        $index = $this->sigmie->collect($indexName, refresh: true);
+
+        $index->merge([
+            new Document(['name' => 'Alice', 'category' => 'public', 'active' => true]),
+            new Document(['name' => 'Bob', 'category' => 'public', 'active' => false]),
+            new Document(['name' => 'Carol', 'category' => 'private', 'active' => true]),
+        ]);
+
+        // Baseline: the OR string filter alone matches all three documents.
+        $res = $this->sigmie->newSearch($indexName)
+            ->properties($blueprint)
+            ->queryString('')
+            ->filters("category:'public' OR category:'private'")
+            ->get();
+
+        $this->assertEquals(3, $res->total());
+
+        // The hard clause is ANDed on top without corrupting the OR (should)
+        // semantics: only the active documents from either category survive.
+        $res = $this->sigmie->newSearch($indexName)
+            ->properties($blueprint)
+            ->queryString('')
+            ->filters("category:'public' OR category:'private'")
+            ->filterQuery(new Term('active', true))
+            ->get();
+
+        $names = array_map(fn (array $hit): string => $hit['_source']['name'], $res->json('hits'));
+
+        sort($names);
+
+        $this->assertEquals(2, $res->total());
+        $this->assertEquals(['Alice', 'Carol'], $names);
     }
 }


### PR DESCRIPTION
## Why

`NewSearch::filters()` only accepted a `string` and always routed it through `FilterParser`. In the search path the parser runs with `throwOnError = false` (`NewSearch.php:92`), so an unknown/malformed clause is **silently dropped** and the search proceeds — a fail-*open* behaviour. That makes it unsafe to express security-critical scoping (tenant id, consent, ACL) inside the user-supplied filter string, because a dropped clause *broadens* results.

This adds a way to attach a pre-built query as a **hard clause** that the parser never sees.

## What

- `NewSearch::filterQuery(Query $query): static` — appends a raw query clause.
- `appliedFilters()` composes the parsed string filter with any `filterQuery()` clauses as **siblings in a single filter context**, so they are ANDed together. The parsed query stays nested as one clause, so its own `should`/`must_not` (OR/NOT) semantics are not corrupted by the added `filter` clauses.
- Applied at every site that consumes the parsed filter: the main bool filter, facet search, and vector/knn pre-filtering.

```php
$search->filters("age>18")              // user filter (parsed, may fail open)
       ->filterQuery(new Term('tenant_id', $tenantId));  // hard clause, never parsed

// filter MUST [ parsed(age>18) AND term(tenant_id) ]
```

`filters()` and `filterQuery()` are order-independent — the composition happens at build time, not on assignment.

## Test

`filter_query_ands_a_hard_clause_with_the_string_filter` (`tests/SearchTest.php`): an `OR` string filter matches 3 docs; adding `filterQuery(new Term('active', true))` narrows to the 2 active docs across *both* OR branches — proving the clause ANDs **and** that the `should` semantics survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)