### PR TITLE
fix: teach correct sort syntax instead of "Field asc does not exist"

### DIFF
--- a/src/AI/SigmieIndexTool.php
+++ b/src/AI/SigmieIndexTool.php
@@ -65,7 +65,7 @@ class SigmieIndexTool implements Tool
             ."Negation: NOT field:'value'\n"
             ."Grouping: (field:'a' OR field:'b') AND other>10\n"
             ."Exists check: field:*\n"
-            ."Sort: field:asc field:desc _score (space-separated)\n"
+            ."Sort: space-separated list of 'field:asc' or 'field:desc' — the direction goes after a COLON (e.g. 'price:asc name:desc'), plus '_score'. A space before the direction ('price asc') is INVALID.\n"
             ."Geo sort: field[lat,lon]:km:asc\n"
             ."Facets: field1 field2:20 (space-separated, optional :size for keywords or :interval for numbers)\n"
             ."Discovering valid values: if you do not know a field's valid values, call the companion value-discovery tool (discover_filter_values) with the field name and an optional query before filtering.");

--- a/src/Parse/SortParser.php
+++ b/src/Parse/SortParser.php
@@ -29,6 +29,20 @@ class SortParser extends Parser
                 continue;
             }
 
+            // A bare "asc"/"desc" token means the direction was written with a space
+            // (SQL-style "field asc") instead of a colon. Point to the correct form so
+            // the caller (or an agent) can fix it rather than seeing "Field asc does not exist".
+            if (in_array($match, ['asc', 'desc'], true)) {
+                $this->handleError(sprintf(
+                    "Invalid sort '%s': attach the direction to its field with a colon, e.g. 'field:%s' (not 'field %s'). Use 'field:asc' or 'field:desc', and separate multiple sorts with spaces, e.g. 'price:asc name:desc'.",
+                    $string,
+                    $match,
+                    $match
+                ), ['token' => $match]);
+
+                continue;
+            }
+
             // Handle _score with direction
             if (str_starts_with($match, '_score:')) {
                 $direction = substr($match, 7); // Remove '_score:'

--- a/tests/SigmieIndexToolTest.php
+++ b/tests/SigmieIndexToolTest.php
@@ -781,7 +781,7 @@ class SigmieIndexToolTest extends TestCase
         ])), true);
 
         $this->assertArrayHasKey('error', $result);
-        $this->assertStringContainsString("field:asc", $result['error']);
+        $this->assertStringContainsString('field:asc', $result['error']);
     }
 
     /**

--- a/tests/SigmieIndexToolTest.php
+++ b/tests/SigmieIndexToolTest.php
@@ -774,14 +774,14 @@ class SigmieIndexToolTest extends TestCase
 
         // SQL-style "price asc" (a space instead of "price:asc") makes the sort parser throw.
         // handle() must return it as an {"error": ...} the agent can correct, not propagate
-        // an exception that aborts the turn.
+        // an exception that aborts the turn — and the message must show the correct syntax.
         $result = json_decode((new SigmieIndexTool($index))->handle(new Request([
             'query' => '',
             'sort' => 'price asc',
         ])), true);
 
         $this->assertArrayHasKey('error', $result);
-        $this->assertNotEmpty($result['error']);
+        $this->assertStringContainsString("field:asc", $result['error']);
     }
 
     /**

--- a/tests/SortParserTest.php
+++ b/tests/SortParserTest.php
@@ -746,4 +746,22 @@ class SortParserTest extends TestCase
         $this->assertTrue($hits[1]['_source']['created_at'] === '2023-05-07T12:38:29.000000Z');
         $this->assertTrue($hits[2]['_source']['created_at'] === '2023-06-07T12:38:29.000000Z');
     }
+
+    /**
+     * @test
+     */
+    public function space_separated_direction_throws_a_helpful_error(): void
+    {
+        $blueprint = new NewProperties;
+        $blueprint->number('price');
+
+        $parser = new SortParser($blueprint());
+
+        // SQL-style "price asc" (a space instead of "price:asc") used to throw the misleading
+        // "Field asc does not exist." — now it teaches the correct colon form.
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessageMatches('/field:asc/');
+
+        $parser->parse('price asc');
+    }
 }


### PR DESCRIPTION
## Why

In a live agent eval, the model asked for "cheapest first" wrote a SQL-style sort `monthly_price asc` (space instead of `monthly_price:asc`). The parser split on the space, read `asc` as a field, and threw:

> `Field asc does not exist.`

That message is useless — it names the wrong problem. With #72 surfacing it to the agent, the agent didn't fix the syntax; it **dropped the direction** (`sort: monthly_price`) to avoid the error. That happened to be right only because a bare field defaults to ascending *and* the data was uniformly priced — for a "most expensive first" request the same dodge would have silently returned the wrong order.

The fix is to **describe the correct usage** — both up front and at the moment of failure.

## What

- **`SortParser`** — a bare `asc`/`desc` token (the SQL-style mistake) now throws a directive message instead of "Field asc does not exist":
  > `Invalid sort 'price asc': attach the direction to its field with a colon, e.g. 'field:asc' (not 'field asc'). Use 'field:asc' or 'field:desc', and separate multiple sorts with spaces, e.g. 'price:asc name:desc'.`
- **`SigmieIndexTool`** — the `Sort:` line in the tool description now spells out the colon rule and that `price asc` is invalid.

Grammar is unchanged (still strict `field:asc`); only the guidance improved. Paired with #72, the message reaches the agent as the tool's `{"error": …}`, so it corrects to `field:asc` rather than guessing.

## Tests (51 passing)

- `SortParserTest::space_separated_direction_throws_a_helpful_error` — `parse('price asc')` throws a `ParseException` whose message contains `field:asc`.
- `SigmieIndexToolTest::handle_surfaces_malformed_sort_as_error` — now asserts the surfaced `{"error"}` contains `field:asc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)