### PR TITLE
fix: honor throwOnError in filters()/facets() + add filterQuery() to the contract

### DIFF
--- a/src/Parse/Parser.php
+++ b/src/Parse/Parser.php
@@ -34,6 +34,13 @@ abstract class Parser implements ParserInterface
         return $this;
     }
 
+    public function throwOnError(bool $throwOnError = true): static
+    {
+        $this->throwOnError = $throwOnError;
+
+        return $this;
+    }
+
     abstract public function parse(string $string);
 
     protected function handleError(string $message, array $context = [])

--- a/src/Search/AbstractSearchBuilder.php
+++ b/src/Search/AbstractSearchBuilder.php
@@ -10,6 +10,7 @@ use Sigmie\Mappings\Properties;
 use Sigmie\Mappings\Properties as MappingsProperties;
 use Sigmie\Query\Aggs as FacetAggs;
 use Sigmie\Query\Contracts\Aggs;
+use Sigmie\Query\Contracts\QueryClause;
 use Sigmie\Query\Queries\Compound\Boolean;
 use Sigmie\Search\Contracts\SearchBuilder;
 
@@ -67,6 +68,8 @@ abstract class AbstractSearchBuilder implements SearchBuilder
 
     protected Boolean $globalFilters;
 
+    protected array $filterQueries = [];
+
     protected Boolean $facetFilters;
 
     protected Aggs $facets;
@@ -97,6 +100,13 @@ abstract class AbstractSearchBuilder implements SearchBuilder
         if ($this->fields === []) {
             $this->fields = $this->properties->fieldNames();
         }
+
+        return $this;
+    }
+
+    public function filterQuery(QueryClause $query): static
+    {
+        $this->filterQueries[] = $query;
 
         return $this;
     }

--- a/src/Search/Contracts/SearchQueryBuilder.php
+++ b/src/Search/Contracts/SearchQueryBuilder.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Sigmie\Search\Contracts;
 
 use Sigmie\Mappings\Properties;
+use Sigmie\Query\Contracts\QueryClause;
 
 interface SearchQueryBuilder extends SearchBuilder
 {
     public function properties(Properties $properties): static;
 
     public function filters(string $filters): static;
+
+    public function filterQuery(QueryClause $query): static;
 
     public function sort(string $sort): static;
 }

--- a/src/Search/NewSearch.php
+++ b/src/Search/NewSearch.php
@@ -82,8 +82,6 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
 
     protected int $collapseTop = 0;
 
-    protected array $filterQueries = [];
-
     public function __construct(
         ElasticsearchConnection $elasticsearchConnection
     ) {
@@ -172,18 +170,13 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
         return $this;
     }
 
-    public function filters(string $filters, bool $thorwOnError = true): static
+    public function filters(string $filters, bool $throwOnError = false): static
     {
         $this->searchContext->filterString = $filters;
 
-        $this->globalFilters = $this->filterParser->parse($this->searchContext->filterString);
-
-        return $this;
-    }
-
-    public function filterQuery(Query $query): static
-    {
-        $this->filterQueries[] = $query;
+        $this->globalFilters = $this->filterParser
+            ->throwOnError($throwOnError)
+            ->parse($this->searchContext->filterString);
 
         return $this;
     }
@@ -225,7 +218,10 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
     public function facets(
         string $facets,
         string $filters = '',
+        bool $throwOnError = false,
     ): static {
+
+        $this->facetParser->throwOnError($throwOnError);
 
         $facetFilterString = $this->facetParser->parseFilterString($filters);
 
@@ -234,7 +230,7 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
         $this->searchContext->facetFilterString = $facetFilterString;
 
         if ($facetFilterString !== '') {
-            $this->facetFilters = $this->filterParser->parse($facetFilterString);
+            $this->facetFilters = $this->filterParser->throwOnError($throwOnError)->parse($facetFilterString);
         }
 
         $this->facets = $this->facetParser->parse($facets, $facetFilterString);
@@ -242,9 +238,9 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
         return $this;
     }
 
-    public function sort(string $sort = '_score', bool $thorwOnError = true): static
+    public function sort(string $sort = '_score', bool $throwOnError = true): static
     {
-        $parser = new SortParser($this->properties, $thorwOnError);
+        $parser = new SortParser($this->properties, $throwOnError);
 
         $this->searchContext->sortString = $sort;
         $this->sort = $parser->parse($sort);

--- a/src/Search/NewTemplate.php
+++ b/src/Search/NewTemplate.php
@@ -104,6 +104,12 @@ class NewTemplate extends AbstractSearchBuilder implements SearchTemplateBuilder
 
         $boolean->must()->bool(fn (Boolean $boolean) => $boolean->addRaw('filter', sprintf('@filters(%s)@endfilters', $defaultFilters)));
 
+        (new Collection($this->filterQueries))->each(
+            fn (QueryClause $query): BooleanQueryBuilder => $boolean->must()->bool(
+                fn (Boolean $boolean): BooleanQueryBuilder => $boolean->filter()->query($query)
+            )
+        );
+
         $defaultSorts = json_encode($this->sort);
 
         $search->addRaw('sort', sprintf('@sort(%s)@endsort', $defaultSorts));

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -11,6 +11,7 @@ use Sigmie\Document\Hit;
 use Sigmie\Languages\English\English;
 use Sigmie\Languages\German\German;
 use Sigmie\Mappings\NewProperties;
+use Sigmie\Parse\ParseException;
 use Sigmie\Query\Queries\Term\Range;
 use Sigmie\Query\Queries\Term\Term;
 use Sigmie\Testing\TestCase;
@@ -1599,5 +1600,50 @@ class SearchTest extends TestCase
         $facets = $props['category']->facets($res->facetAggregations());
 
         $this->assertEquals(['private' => 1, 'public' => 1], $facets);
+    }
+
+    /**
+     * @test
+     */
+    public function filters_throw_on_error_can_be_opted_into(): void
+    {
+        $blueprint = new NewProperties;
+        $blueprint->keyword('category');
+
+        $this->expectException(ParseException::class);
+
+        $this->sigmie->newSearch('test')
+            ->properties($blueprint)
+            ->filters("nonexistent:'x'", throwOnError: true);
+    }
+
+    /**
+     * @test
+     */
+    public function filters_collect_errors_by_default_instead_of_throwing(): void
+    {
+        $blueprint = new NewProperties;
+        $blueprint->keyword('category');
+
+        $search = $this->sigmie->newSearch('test')
+            ->properties($blueprint)
+            ->filters("nonexistent:'x'");
+
+        $this->assertNotEmpty($search->filterParser->errors());
+    }
+
+    /**
+     * @test
+     */
+    public function facets_throw_on_error_can_be_opted_into(): void
+    {
+        $blueprint = new NewProperties;
+        $blueprint->keyword('category');
+
+        $this->expectException(ParseException::class);
+
+        $this->sigmie->newSearch('test')
+            ->properties($blueprint)
+            ->facets('category', "nonexistent:'x'", throwOnError: true);
     }
 }


### PR DESCRIPTION
Follow-up to #73. Addresses the residual concerns flagged after that merge.

## #1 / #2 — `throwOnError` is now actually honored

`NewSearch::filters()` declared `bool $thorwOnError = true` — **misspelled and never read**. The filter parser was built once with fail-open mode (`NewSearch.php:92`), so a caller doing `->filters($input, throwOnError: true)` to opt into strict, fail-*closed* parsing was silently ignored and still fell open. That defeats the safe pattern for sensitive (e.g. PHI) queries.

- New reusable `Parser::throwOnError(bool): static` setter.
- `filters(string, bool $throwOnError = false)` wires it through. **Default `false` preserves today's fail-open behaviour** (the param was effectively always-false before), so this is backward compatible — verified no caller passes a second arg.
- `facets(string, string, bool $throwOnError = false)` gains the same opt-in (its facet-filter parse previously had no way to throw).
- Fixed the `sort()` typo (`$thorwOnError` → `$throwOnError`; it was already wired correctly).

```php
// opt into fail-closed parsing for sensitive queries
$search->filters($userFilter, throwOnError: true);   // throws ParseException on a bad clause
$search->facets($f, $userFacetFilter, throwOnError: true);
```

## #5 — `filterQuery()` on the contract

Added `filterQuery(QueryClause): static` to `SearchQueryBuilder` so code typed against the interface can use the hard-clause API from #73.

Because `SearchTemplateBuilder extends SearchQueryBuilder`, the deprecated `NewTemplate` must satisfy it too. Rather than duplicate, the storage (`filterQueries`) and the `filterQuery()` method move down to `AbstractSearchBuilder` (one implementation for both). `NewTemplate::get()` now bakes any hard clauses in as **always-present** filter clauses (outside the `@filters(...)` placeholder), so a template can carry a permanent scoping clause.

## Not included

Field-level allowlisting (#3) — decided to handle at the application layer.

## Tests

`tests/SearchTest.php`:
- `filters_throw_on_error_can_be_opted_into` — `throwOnError: true` throws `ParseException` on an unknown field.
- `filters_collect_errors_by_default_instead_of_throwing` — default collects into `filterParser->errors()`, no throw.
- `facets_throw_on_error_can_be_opted_into` — same opt-in works for the facet filter.

Not run (need a live ES cluster, per repo convention) — please run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)