### PR TITLE
docs: document filterQuery() and throwOnError parsing

### DIFF
--- a/docs/facets.md
+++ b/docs/facets.md
@@ -141,6 +141,12 @@ $sigmie->newSearch('products')
     ->get();
 ```
 
+Like `filters()`, the facet filter string is parsed leniently — an invalid clause is dropped and recorded under the response's `errors` key. Pass `throwOnError: true` as the third argument to raise a `ParseException` instead:
+
+```php
+->facets('brand category', "brand:'Apple'", throwOnError: true)
+```
+
 ## Disjunctive vs conjunctive
 
 E-commerce facets usually want **disjunctive** logic: selecting two brands should show items from either brand, and both brand options should remain visible in the sidebar.

--- a/docs/filter-parser.md
+++ b/docs/filter-parser.md
@@ -283,6 +283,23 @@ if (!empty($parser->errors())) {
 }
 ```
 
+### Throwing vs collecting
+
+Whether a bad filter throws or is collected depends on how the parser is invoked:
+
+- **Directly** (`new FilterParser(...)`) or via `newQuery()` — throws `ParseException` on the first error.
+- **Via `newSearch()`** — lenient by default: the bad clause is dropped, the search runs, and the error is collected under the response's `errors` key.
+
+Opt into throwing on the search builder with `throwOnError`:
+
+```php
+$sigmie->newSearch('products')
+    ->properties($props)
+    ->filters('nonexistent:"x"', throwOnError: true);   // throws instead of collecting
+```
+
+When a silently-dropped clause would be unsafe — returning a broader result set than intended — pass `throwOnError: true` and treat a non-empty `errors` array as a failed request rather than a warning.
+
 ## Syntax cheatsheet
 
 | Operation | Syntax | Example |

--- a/docs/search.md
+++ b/docs/search.md
@@ -87,6 +87,52 @@ $sigmie->newSearch('fairy-tales')
 
 Filters narrow the result set but don't affect relevance scoring.
 
+### Hard filter clauses with `filterQuery()`
+
+`filters()` parses a user-facing string. When a filter must **not** come from user input — a tenant scope, an ownership check, an access boundary — pass a pre-built query to `filterQuery()` instead:
+
+```php
+use Sigmie\Query\Queries\Term\Term;
+
+$sigmie->newSearch('records')
+    ->properties($props)
+    ->queryString('checkup')
+    ->filters("category:'public' OR category:'private'")   // user input, parsed
+    ->filterQuery(new Term('tenant_id', $tenantId))         // hard clause, never parsed
+    ->get();
+```
+
+The hard clause is ANDed with the parsed filter. Because it never passes through the parser, a malformed filter string can't drop it, and it doesn't alter the parsed query's own `OR`/`NOT` logic — that stays nested as a single clause. It applies everywhere the filter does: results, facet counts, and semantic (vector) pre-filtering. Call it more than once to add several clauses.
+
+`filterQuery()` accepts any query clause, so you're not limited to the parser's syntax:
+
+```php
+use Sigmie\Query\Queries\Term\Terms;
+
+->filterQuery(new Terms('owner_id', $allowedOwnerIds))
+```
+
+### Strict vs lenient parsing
+
+By default `newSearch()` is **lenient**: an invalid filter clause is dropped, the search still runs, and the reason is collected under the response's `errors` key:
+
+```php
+$response = $sigmie->newSearch('products')
+    ->properties($props)
+    ->filters('nonexistent:"x"')
+    ->get();
+
+$response->json('errors');   // [['message' => 'Field nonexistent does not exist.', ...]]
+```
+
+To fail loudly instead — so a bad filter raises a `ParseException` rather than silently returning a broader result set — opt in with `throwOnError`:
+
+```php
+->filters('nonexistent:"x"', throwOnError: true)     // throws ParseException
+```
+
+The same flag is available on [`facets()`](facets.md) for the facet filter string.
+
 ## Sort
 
 ```php


### PR DESCRIPTION
Documents the filter APIs added in #73 (`filterQuery()`) and #75 (`throwOnError` on `filters()`/`facets()`). No code changes — docs only.

## What's added

**`docs/search.md`** — under *Filter*:
- **Hard filter clauses with `filterQuery()`** — passing a pre-built query (tenant scope, ownership/access boundary) that's ANDed with the parsed string filter, never goes through the parser, and applies to results, facet counts, and vector pre-filtering.
- **Strict vs lenient parsing** — `newSearch()` is lenient by default (bad clause dropped, reason under the response `errors` key); `throwOnError: true` makes it raise `ParseException`.

**`docs/filter-parser.md`** — new *Throwing vs collecting* subsection: the parser throws when used directly / via `newQuery()`, but collects via `newSearch()`; how to opt into throwing, and to treat a non-empty `errors` array as a failed request when a dropped clause would be unsafe.

**`docs/facets.md`** — note that the facet filter string is parsed leniently too, with the `throwOnError` third argument.

All examples follow the existing page style and use the real constructor signatures (`Term($field, $value)`, `Terms($field, array)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)