### PR TITLE
feat: lean tool descriptions (opt-in) to scale multi-index agents

### DIFF
--- a/src/AI/AsTool.php
+++ b/src/AI/AsTool.php
@@ -34,12 +34,16 @@ trait AsTool
      * The agent tool suite for this index: search, on-demand value discovery, sample documents,
      * and the structured schema (field list + filter syntax).
      *
+     * Pass $describeFields: false for "lean" mode — the search tool's description drops the inline
+     * field list and points the agent to describe_index instead. Useful when many indices are
+     * registered and the combined tool descriptions would bloat the system prompt.
+     *
      * @return array{0: SigmieIndexTool, 1: SigmieFilterValuesTool, 2: SigmieSampleDocumentsTool, 3: SigmieIndexSchemaTool}
      */
-    public function tools(string $baseFilter = ''): array
+    public function tools(string $baseFilter = '', bool $describeFields = true): array
     {
         return [
-            new SigmieIndexTool($this, $baseFilter),
+            new SigmieIndexTool($this, $baseFilter, $describeFields),
             new SigmieFilterValuesTool($this, $baseFilter),
             new SigmieSampleDocumentsTool($this),
             new SigmieIndexSchemaTool($this),

--- a/src/AI/SigmieIndexTool.php
+++ b/src/AI/SigmieIndexTool.php
@@ -34,10 +34,24 @@ class SigmieIndexTool implements Tool
     public function __construct(
         protected SigmieIndex $index,
         protected string $baseFilters = '',
+        protected bool $describeFields = true,
     ) {}
 
     public function description(): string
     {
+        // Lean mode: omit the per-field list and operator docs from the always-present description
+        // (keeps the system prompt small when many indices are registered) and point the agent to
+        // describe_index for the schema on demand. Still lists field NAMES so it can decide to search.
+        if (! $this->describeFields) {
+            $names = array_column($this->fieldsSchema(), 'name');
+
+            return sprintf(
+                "Search the '%s' index. Fields: %s. Before building filters or sorts, call describe_index for each field's type and meaning and the exact filter/sort/facet syntax.",
+                $this->index->name(),
+                implode(', ', $names)
+            );
+        }
+
         $properties = $this->index->properties()->get();
 
         $fieldDescriptions = $this->collectFieldDescriptions($properties->toArray());

--- a/tests/SigmieIndexToolTest.php
+++ b/tests/SigmieIndexToolTest.php
@@ -641,6 +641,44 @@ class SigmieIndexToolTest extends TestCase
     /**
      * @test
      */
+    public function lean_description_drops_field_block_and_points_to_describe_index(): void
+    {
+        $index = $this->createProductIndex();
+
+        $description = (new SigmieIndexTool($index, describeFields: false))->description();
+
+        // Still names the fields so the agent can decide to search...
+        $this->assertStringContainsString('brand', $description);
+        $this->assertStringContainsString('price', $description);
+        // ...but drops the verbose per-field block, examples and operator docs...
+        $this->assertStringNotContainsString('Available fields:', $description);
+        $this->assertStringNotContainsString("brand:'value'", $description);
+        $this->assertStringNotContainsString('Filter operators:', $description);
+        // ...and points to the schema tool instead.
+        $this->assertStringContainsString('describe_index', $description);
+
+        // The verbose default still includes the field block (no regression).
+        $verbose = (new SigmieIndexTool($index))->description();
+        $this->assertStringContainsString('Available fields:', $verbose);
+        $this->assertStringContainsString("brand:'value'", $verbose);
+    }
+
+    /**
+     * @test
+     */
+    public function tools_lean_mode_produces_a_lean_search_tool(): void
+    {
+        $index = $this->createProductIndex();
+
+        $description = $index->tools('', describeFields: false)[0]->description();
+
+        $this->assertStringNotContainsString('Available fields:', $description);
+        $this->assertStringContainsString('describe_index', $description);
+    }
+
+    /**
+     * @test
+     */
     public function describe_index_returns_structured_fields_and_syntax(): void
     {
         $index = $this->createProductIndex();


### PR DESCRIPTION
## Why

`SigmieIndexTool::description()` inlines the full per-field list, filter examples and operator docs. For a single index that's great. But with several `AsTool` indices registered, that whole block is repeated for **each** index in the system prompt, on **every** turn.

Two multi-index evals (legal RAG; then a 51-run medical + legal high-stakes run) showed `describe_index` was called **0 times** — *because* the full schema is already inline, the agent never needs to fetch it. So the schema tool can't earn its keep until the search description goes lean.

## What

Opt-in **lean mode**. When `describeFields: false`, the search tool's description becomes one line:

```
Search the 'products' index. Fields: name, brand, price, in_stock, created_at.
Before building filters or sorts, call describe_index for each field's type and
meaning and the exact filter/sort/facet syntax.
```

It still **names** the fields (so the agent can decide to search/route) but drops the ~15 lines of per-field examples + operator docs, which now live behind `describe_index` (added in #76).

- `SigmieIndexTool`: new `bool $describeFields = true` constructor arg.
- `AsTool::tools(string $baseFilter = '', bool $describeFields = true)` threads it through.
- **Default is unchanged (verbose)** — fully backward compatible. Opt in per index / per app.

## Tests (39 passing)

- `lean_description_drops_field_block_and_points_to_describe_index` — lean output omits `Available fields:`, the `brand:'value'` examples and `Filter operators:`, still names fields, and contains `describe_index`; the verbose default is unchanged.
- `tools_lean_mode_produces_a_lean_search_tool` — `tools('', describeFields: false)` yields a lean search tool.

## Note / follow-up

This adds the *capability*. The tradeoff is a tool-call hop (the agent must call `describe_index` before filtering), and there's a real risk the model filters without fetching the schema. Worth validating with a multi-index eval (lean enabled) to confirm `describe_index` gets used and retrieval quality holds before recommending lean as a default for many-index setups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)