### PR TITLE
docs(AI): add phrasing→widget disambiguation to SigmieAnalyticsTool

### DIFF
--- a/src/AI/SigmieAnalyticsTool.php
+++ b/src/AI/SigmieAnalyticsTool.php
@@ -66,6 +66,19 @@ class SigmieAnalyticsTool implements Tool
             ."- distribution: histogram of a numeric field (needs field, bucket_size)\n"
             .'- percentiles: p50/p75/p95/p99 of a numeric field (needs field)';
 
+        // Phrasing → widget hints. Disambiguates the common trap where 'monthly/weekly/daily X
+        // over <period>' reads as 'one number for the period' (kpi) instead of 'a series bucketed
+        // at that interval' (trend). Without this, small models (gpt-4o-mini, gpt-4.1-mini) drop
+        // the time-series when the user names the bucket inside the phrase.
+        $description .= "\n\nChoosing a widget — match the phrasing:\n"
+            ."- \"daily / weekly / monthly / hourly X over <period>\" or \"X per day/week/month\" → trend (use interval=day|week|month|hour). NOT kpi — the bucket word means a series.\n"
+            ."- \"X over time\", \"trend of X\", \"X by <date_field>\" → trend\n"
+            ."- \"running total\", \"cumulative X\", \"growth curve\" → cumulative\n"
+            ."- \"top N <thing> by X\", \"best <thing>\", \"which <thing> drove the most X\" → breakdown (group_by=<thing>)\n"
+            ."- \"X this month\" / \"average X last week\" with no bucket word → kpi (or kpi_delta when the user compares to a prior period)\n"
+            ."- \"distribution of X\", \"histogram of X\" → distribution\n"
+            .'- "p50/p75/p95/p99", "percentiles of X", "median X" → percentiles';
+
         $description .= "\n\nMetrics (`metric`): sum, avg, min, max, count, unique (distinct), median.";
         $description .= "\n\nIntervals (`interval`): minute, hour, day, week, month, quarter, year.";
         $description .= "\n\nRelative window (`range`, preferred over from/to): today, yesterday, this_week, last_week, this_month, last_month, this_quarter, last_quarter, this_year, last_year, last_7_days, last_30_days, last_90_days. A calendar range makes kpi_delta compare against the previous instance (this_month vs last_month).";

--- a/tests/SigmieAnalyticsToolTest.php
+++ b/tests/SigmieAnalyticsToolTest.php
@@ -95,6 +95,36 @@ class SigmieAnalyticsToolTest extends TestCase
     }
 
     /**
+     * The 'Choosing a widget' phrasing guide is what stops a small model from reading
+     * 'monthly revenue for the last 90 days' as 'one number' (kpi) instead of 'a series
+     * bucketed monthly' (trend). Asserts the disambiguation hints are present so they
+     * don't quietly drift away in a future edit.
+     *
+     * @test
+     */
+    public function description_includes_phrasing_to_widget_disambiguation(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $description = (new SigmieAnalyticsTool($index))->description();
+
+        // Section header.
+        $this->assertStringContainsString('Choosing a widget', $description);
+
+        // The bucket-word trap is named explicitly.
+        $this->assertStringContainsString('daily / weekly / monthly / hourly', $description);
+        $this->assertStringContainsString('NOT kpi', $description);
+        $this->assertStringContainsString('the bucket word means a series', $description);
+
+        // Each widget has a phrasing entry.
+        $this->assertStringContainsString('cumulative', $description);
+        $this->assertStringContainsString('top N', $description);
+        $this->assertStringContainsString('with no bucket word', $description);
+        $this->assertStringContainsString('histogram', $description);
+        $this->assertStringContainsString('percentiles', $description);
+    }
+
+    /**
      * @test
      */
     public function schema_marks_required_and_optional_params_for_openai_strict(): void


### PR DESCRIPTION
## Why

The Jarvis dashboard eval (23 prompts × Haiku 4.5 / gpt-4o-mini / gpt-4.1-mini — 69 turns total against a real `SigmieAnalyticsTool` + `OrderIndex`) found a single repeated semantic miss:

> *"Monthly revenue for the last 90 days"* — both OpenAI mini models read this as **"one number for the period"** (`widget=kpi`) instead of **"a series bucketed monthly over 90 days"** (`widget=trend, interval=month`). Haiku 4.5 reads it correctly.

The trap is linguistic. When the user names the bucket word (*monthly* / *weekly* / *daily* / *hourly*) **inside** the phrase, smaller models tend to read it as an adjective on the headline number rather than the series cadence.

It's the only real precision miss the eval surfaced. Everything else was either rigid scorecard semantics (the agent picking the richer `kpi_delta` over `kpi`, or `cumulative` subsuming `kpi`) or already-correct behaviour.

## What

Adds a *"Choosing a widget — match the phrasing"* block to the tool description that pattern-matches user phrasing to widget kinds. Eight short lines, one per common pattern, with the bucket-word case named explicitly:

```
- "daily / weekly / monthly / hourly X over <period>" or "X per day/week/month"
    → trend (use interval=day|week|month|hour). NOT kpi — the bucket word means a series.
- "X over time", "trend of X", "X by <date_field>"     → trend
- "running total", "cumulative X", "growth curve"     → cumulative
- "top N <thing> by X", "best <thing>", "which drove the most X" → breakdown
- "X this month" / "average X last week" with no bucket word     → kpi (or kpi_delta when comparing)
- "distribution of X", "histogram of X"                → distribution
- "p50/p75/p95/p99", "percentiles of X", "median X"    → percentiles
```

**No code or schema changes** — pure description tweak. The agent reads the new hints alongside the existing widget descriptions and the per-index field list.

## Tests

`description_includes_phrasing_to_widget_disambiguation` asserts the section header and each phrasing entry stays present, so they don't quietly drift away in a future edit.

```
$ phpunit tests/SigmieAnalyticsToolTest.php
OK (10 tests, 53 assertions)        ← was 9

$ phpunit --filter "AI|Analytics"
OK (49 tests, 193 assertions)        ← no regressions
```

## Eval scorecard the change targets

```
model         pass*  routed  widget  filter*  group_by*  interval*  range  avg_calls  avg_ms  api_err
Haiku 4.5     21/23  23/23   21/23   18/18    9/9        8/8        22/23  1.35       4481    0
gpt-4o-mini   19/23  23/23   20/23   18/18    9/9        8/8        21/23  1.65       5067    0
gpt-4.1-mini  19/23  23/23   19/23   18/18    9/9        8/8        22/23  1.39       5073    0
```
*\* Strict pass; effective ~22-23/23 after debiting eval-spec rigidity. Filter/group_by/interval shown out of prompts where that dimension is applicable.*

The trap fires on the same prompt (Run 10) for both OpenAI minis. With this description block in place, the next eval round should lift them to 23/23 effective on this case — closing the only remaining genuine miss.

## Out of scope

- Multi-turn follow-ups (*"now per month instead"*, *"drill into Spain"*) — separate eval/PR.
- Noisy-prompt eval (typos, abbreviations, mixed languages) — separate eval.
- A `dashboard({widgets:[...]})` tool to collapse N sequential analytics calls into 1 — follow-up after we measure how much it shaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)