### PR TITLE
feat(AI): get_documents tool — retrieve multiple docs by id

### DIFF
--- a/docs/laravel-ai.md
+++ b/docs/laravel-ai.md
@@ -77,6 +77,17 @@ public function tools(): array
 }
 ```
 
+## The tool suite
+
+`tools()` returns the full agent tool suite for the index:
+
+- `search_index` — query, filter, sort, facet and paginate.
+- `discover_filter_values` — list valid values for a field before filtering.
+- `sample_documents` — a few random documents so the agent can see the real data shape.
+- `get_documents` — retrieve specific documents by their `_id` (e.g. ids surfaced by `search_index`). Non-existent ids are omitted.
+- `describe_index` — the structured field list, types and filter syntax.
+- `analytics` — dashboard widgets (KPIs, trends, breakdowns, distributions, percentiles).
+
 ## Base filters
 
 Pass `baseFilters` to scope every query the AI makes. This is how you enforce multi-tenancy or per-user authorization — the AI can't bypass these filters and can't see them in its tool description:

--- a/src/AI/AsTool.php
+++ b/src/AI/AsTool.php
@@ -32,9 +32,9 @@ trait AsTool
 {
     /**
      * The agent tool suite for this index: search, on-demand value discovery, sample documents,
-     * the structured schema (field list + filter syntax), and dashboard analytics.
+     * retrieval by id, the structured schema (field list + filter syntax), and dashboard analytics.
      *
-     * @return array{0: SigmieIndexTool, 1: SigmieFilterValuesTool, 2: SigmieSampleDocumentsTool, 3: SigmieIndexSchemaTool, 4: SigmieAnalyticsTool}
+     * @return array{0: SigmieIndexTool, 1: SigmieFilterValuesTool, 2: SigmieSampleDocumentsTool, 3: SigmieGetDocumentsTool, 4: SigmieIndexSchemaTool, 5: SigmieAnalyticsTool}
      */
     public function tools(string $baseFilter = ''): array
     {
@@ -42,6 +42,7 @@ trait AsTool
             new SigmieIndexTool($this, $baseFilter),
             new SigmieFilterValuesTool($this, $baseFilter),
             new SigmieSampleDocumentsTool($this),
+            new SigmieGetDocumentsTool($this),
             new SigmieIndexSchemaTool($this),
             new SigmieAnalyticsTool($this, $baseFilter),
         ];

--- a/src/AI/SigmieGetDocumentsTool.php
+++ b/src/AI/SigmieGetDocumentsTool.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\AI;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Sigmie\SigmieIndex;
+
+/**
+ * Fetches specific documents from the index by their `_id`. Use after search_index or
+ * sample_documents surface an `_id` the agent wants to read in full.
+ *
+ * Reuses the index's `collect()->getMany()` multi-get (Elasticsearch `_mget`). IDs that do not
+ * exist are simply absent from the returned documents.
+ */
+class SigmieGetDocumentsTool implements Tool
+{
+    use HandlesToolErrors;
+
+    public function __construct(
+        protected SigmieIndex $index,
+    ) {}
+
+    public function name(): string
+    {
+        return 'get_documents';
+    }
+
+    public function description(): string
+    {
+        return sprintf(
+            "Retrieve specific documents from the '%s' index by their `_id`. Pass the ids you already learned from search_index or sample_documents. Ids that do not exist are omitted from the result.",
+            $this->index->name()
+        );
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'ids' => $schema->array()->items($schema->string())
+                ->description('Document ids to retrieve (1-100)')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        return $this->guard(fn (): string => json_encode($this->result($request), JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * The retrieved documents as an array, for callers that want data instead of the JSON string handle() returns.
+     */
+    public function result(Request $request): array
+    {
+        $ids = array_slice(array_values(array_filter(
+            (array) ($request['ids'] ?? []),
+            fn ($id): bool => is_string($id) && $id !== '',
+        )), 0, 100);
+
+        return $this->index->collect()->getMany($ids);
+    }
+}

--- a/tests/SigmieAnalyticsToolTest.php
+++ b/tests/SigmieAnalyticsToolTest.php
@@ -74,7 +74,7 @@ class SigmieAnalyticsToolTest extends TestCase
 
         $tools = $index->tools();
 
-        $this->assertInstanceOf(SigmieAnalyticsTool::class, $tools[4]);
+        $this->assertInstanceOf(SigmieAnalyticsTool::class, $tools[5]);
     }
 
     /**

--- a/tests/SigmieIndexToolTest.php
+++ b/tests/SigmieIndexToolTest.php
@@ -14,6 +14,7 @@ require_once __DIR__.'/Stubs/LaravelAiStubs.php';
 use Laravel\Ai\Tools\Request;
 use Sigmie\AI\AsTool;
 use Sigmie\AI\SigmieFilterValuesTool;
+use Sigmie\AI\SigmieGetDocumentsTool;
 use Sigmie\AI\SigmieIndexSchemaTool;
 use Sigmie\AI\SigmieIndexTool;
 use Sigmie\AI\SigmieSampleDocumentsTool;
@@ -631,11 +632,12 @@ class SigmieIndexToolTest extends TestCase
     {
         $index = $this->createProductIndex();
 
-        [$search, $values, $sample, $schema] = $index->tools();
+        [$search, $values, $sample, $get, $schema] = $index->tools();
 
         $this->assertInstanceOf(SigmieIndexTool::class, $search);
         $this->assertInstanceOf(SigmieFilterValuesTool::class, $values);
         $this->assertInstanceOf(SigmieSampleDocumentsTool::class, $sample);
+        $this->assertInstanceOf(SigmieGetDocumentsTool::class, $get);
         $this->assertInstanceOf(SigmieIndexSchemaTool::class, $schema);
     }
 
@@ -827,6 +829,42 @@ class SigmieIndexToolTest extends TestCase
         $this->assertCount(2, $result);
         $this->assertArrayHasKey('_id', $result[0]);
         $this->assertArrayHasKey('_source', $result[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function get_documents_returns_requested_documents_by_id(): void
+    {
+        $index = $this->createProductIndex();
+
+        $index->merge([
+            new Document(['name' => 'iPhone', 'brand' => 'Apple', 'price' => 999, 'in_stock' => true, 'created_at' => '2024-01-15'], 'doc_1'),
+            new Document(['name' => 'Galaxy', 'brand' => 'Samsung', 'price' => 899, 'in_stock' => true, 'created_at' => '2024-03-10'], 'doc_2'),
+            new Document(['name' => 'Pixel', 'brand' => 'Google', 'price' => 699, 'in_stock' => false, 'created_at' => '2024-04-01'], 'doc_3'),
+        ], refresh: true);
+
+        // Requests two existing ids and one that does not exist; missing ids are omitted.
+        $result = json_decode((new SigmieGetDocumentsTool($index))->handle(new Request(['ids' => ['doc_1', 'doc_3', 'missing']])), true);
+
+        $this->assertCount(2, $result);
+        $this->assertSame(['doc_1', 'doc_3'], array_column($result, '_id'));
+        $this->assertSame('iPhone', $result[0]['_source']['name']);
+    }
+
+    /**
+     * @test
+     */
+    public function get_documents_tool_schema_requires_an_ids_array(): void
+    {
+        $index = $this->createProductIndex();
+
+        $schema = (new SigmieGetDocumentsTool($index))->schema(new FakeJsonSchema);
+
+        $this->assertSame(['ids'], array_keys($schema));
+        $this->assertSame('array', $schema['ids']->type);
+        $this->assertTrue($schema['ids']->required);
+        $this->assertSame('string', $schema['ids']->itemsType->type);
     }
 
     /**

--- a/tests/Stubs/LaravelAiStubs.php
+++ b/tests/Stubs/LaravelAiStubs.php
@@ -12,6 +12,8 @@ namespace Illuminate\Contracts\JsonSchema {
             public function string(): mixed;
 
             public function integer(): mixed;
+
+            public function array(): mixed;
         }
     }
 }
@@ -33,7 +35,16 @@ namespace Sigmie\Tests\Stubs {
 
         public mixed $defaultValue = null;
 
+        public mixed $itemsType = null;
+
         public function __construct(public string $type) {}
+
+        public function items(mixed $type): self
+        {
+            $this->itemsType = $type;
+
+            return $this;
+        }
 
         public function description(string $text): self
         {
@@ -74,6 +85,11 @@ namespace Sigmie\Tests\Stubs {
         public function integer(): FakeSchemaType
         {
             return new FakeSchemaType('integer');
+        }
+
+        public function array(): FakeSchemaType
+        {
+            return new FakeSchemaType('array');
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a `get_documents` tool to the index agent tool suite so agents can retrieve multiple documents by their `_id` in a single call — e.g. ids surfaced by `search_index` or `sample_documents`.

- **`SigmieGetDocumentsTool`** (`src/AI/SigmieGetDocumentsTool.php`) — follows the existing tool pattern (`HandlesToolErrors`, `name()`/`description()`/`schema()`/`handle()`/`result()`). Schema takes a required `ids` array of strings. Backed by `collect()->getMany($ids)` (Elasticsearch `_mget`). Non-existent ids are omitted; input is capped at 100 ids and empty/non-string values are filtered out.
- **Registration** (`src/AI/AsTool.php`) — inserted into `tools()` between `sample_documents` and `describe_index`; updated the trait doc comment and return-type annotation.
- **Docs** (`docs/laravel-ai.md`) — added a "Tool suite" section enumerating all six tools.

## Tests

- Extended the laravel/ai test stub with `array()`/`items()`.
- Added retrieval-by-id and schema tests in `SigmieIndexToolTest`.
- Updated the two existing tests that asserted positional ordering of the suite.

All tool tests pass: `SigmieIndexToolTest` (43) and `SigmieAnalyticsToolTest` (11) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)