### PR TITLE
Support fixed intervals (15d, 90m) in date histograms and trends

### DIFF
--- a/src/AI/SigmieAnalyticsTool.php
+++ b/src/AI/SigmieAnalyticsTool.php
@@ -80,7 +80,7 @@ class SigmieAnalyticsTool implements Tool
             .'- "p50/p75/p95/p99", "percentiles of X", "median X" → percentiles';
 
         $description .= "\n\nMetrics (`metric`): sum, avg, min, max, count, unique (distinct), median.";
-        $description .= "\n\nIntervals (`interval`): minute, hour, day, week, month, quarter, year.";
+        $description .= "\n\nIntervals (`interval`): a calendar unit (minute, hour, day, week, month, quarter, year) or a fixed interval — a multiple of a unit like 15d, 12h, 90m, 30s.";
         $description .= "\n\nRelative window (`range`, preferred over from/to): today, yesterday, this_week, last_week, this_month, last_month, this_quarter, last_quarter, this_year, last_year, last_7_days, last_30_days, last_90_days. A calendar range makes kpi_delta compare against the previous instance (this_month vs last_month).";
         $description .= "\n\nTimezone (`timezone_offset`): minutes east of UTC (Tokyo 540, New York -300). Aligns buckets and ranges to the user's local time. From a browser, send the negation of Date.getTimezoneOffset().";
 
@@ -105,7 +105,7 @@ class SigmieAnalyticsTool implements Tool
             'date_field' => $schema->string()->description('Timeline (date) field to bucket/scope by')->required(),
             'metric' => $schema->string()->description('sum | avg | min | max | count | unique | median (pass null for distribution/percentiles)')->nullable()->required(),
             'field' => $schema->string()->description('Numeric field the metric is computed on (pass null for count)')->nullable()->required(),
-            'interval' => $schema->string()->description('Time bucket for trends: minute | hour | day | week | month | quarter | year (default day)')->default('day')->nullable()->required(),
+            'interval' => $schema->string()->description('Time bucket for trends: a calendar unit (minute | hour | day | week | month | quarter | year) or a fixed interval like 15d | 12h | 90m (default day)')->default('day')->nullable()->required(),
             'group_by' => $schema->string()->description('Keyword field to group/break down by, for breakdown and grouped_trend (pass null otherwise)')->nullable()->required(),
             'limit' => $schema->integer()->description('Max groups for breakdown/grouped_trend (default 10)')->default(10)->nullable()->required(),
             'bucket_size' => $schema->integer()->description('Bucket width for the distribution widget (pass null otherwise)')->nullable()->required(),
@@ -163,7 +163,7 @@ class SigmieAnalyticsTool implements Tool
     {
         $metric = fn (): Metric => $this->metric((string) ($request['metric'] ?? ''));
         $field = (string) ($request['field'] ?? '');
-        $interval = fn (): CalendarInterval => $this->interval((string) ($request['interval'] ?? 'day'));
+        $interval = fn (): CalendarInterval|string => $this->interval((string) ($request['interval'] ?? 'day'));
         $groupBy = fn (): string => $this->required($request, 'group_by');
         $limit = max(1, (int) ($request['limit'] ?? 10));
 
@@ -205,9 +205,17 @@ class SigmieAnalyticsTool implements Tool
         ));
     }
 
-    protected function interval(string $interval): CalendarInterval
+    protected function interval(string $interval): CalendarInterval|string
     {
-        return match (strtolower(trim($interval))) {
+        $interval = strtolower(trim($interval));
+
+        // Fixed interval: a multiple of a unit (15d, 90m, 12h, 30s, 250ms) — Elasticsearch needs
+        // fixed_interval for these, since calendar_interval only allows a single unit.
+        if (preg_match('/^\d+(ms|s|m|h|d)$/', $interval) === 1) {
+            return $interval;
+        }
+
+        return match ($interval) {
             'minute' => CalendarInterval::Minute,
             'hour' => CalendarInterval::Hour,
             '', 'day' => CalendarInterval::Day,
@@ -216,7 +224,7 @@ class SigmieAnalyticsTool implements Tool
             'quarter' => CalendarInterval::Quarter,
             'year' => CalendarInterval::Year,
             default => throw new InvalidArgumentException(sprintf(
-                "Unknown interval '%s'. Use one of: minute, hour, day, week, month, quarter, year.",
+                "Unknown interval '%s'. Use a calendar unit (minute, hour, day, week, month, quarter, year) or a fixed interval like 15d, 12h, 90m.",
                 $interval
             )),
         };

--- a/src/Analytics/Analytics.php
+++ b/src/Analytics/Analytics.php
@@ -180,17 +180,17 @@ class Analytics
         return $this->add(new KpiDelta($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $metric, $this->metricField($metric, $field), $previousFrom, $previousTo));
     }
 
-    public function trend(string $as, Metric $metric, string $field = '', CalendarInterval $interval = CalendarInterval::Day): static
+    public function trend(string $as, Metric $metric, string $field = '', CalendarInterval|string $interval = CalendarInterval::Day): static
     {
         return $this->add(new Trend($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $metric, $this->metricField($metric, $field), $interval, $this->timeZone));
     }
 
-    public function cumulative(string $as, Metric $metric, string $field = '', CalendarInterval $interval = CalendarInterval::Day): static
+    public function cumulative(string $as, Metric $metric, string $field = '', CalendarInterval|string $interval = CalendarInterval::Day): static
     {
         return $this->add(new Cumulative($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $metric, $this->metricField($metric, $field), $interval, $this->timeZone));
     }
 
-    public function groupedTrend(string $as, Metric $metric, string $field, string $groupBy, CalendarInterval $interval = CalendarInterval::Day, int $limit = 5): static
+    public function groupedTrend(string $as, Metric $metric, string $field, string $groupBy, CalendarInterval|string $interval = CalendarInterval::Day, int $limit = 5): static
     {
         return $this->add(new GroupedTrend($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $metric, $this->metricField($metric, $field), $this->aggregatableField($groupBy), $interval, $limit, $this->timeZone));
     }

--- a/src/Analytics/Widgets/Cumulative.php
+++ b/src/Analytics/Widgets/Cumulative.php
@@ -24,7 +24,7 @@ class Cumulative extends Widget
         string $dateFormat,
         protected Metric $metric,
         protected string $field,
-        protected CalendarInterval $interval,
+        protected CalendarInterval|string $interval,
         protected ?string $timeZone = null,
     ) {
         parent::__construct($name, $dateField, $from, $to, $dateFormat);
@@ -49,7 +49,7 @@ class Cumulative extends Widget
             'type' => 'cumulative',
             'metric' => $this->metric->value,
             'field' => $this->field,
-            'interval' => $this->interval->name,
+            'interval' => $this->interval instanceof CalendarInterval ? $this->interval->name : $this->interval,
             'series' => $buckets->map(fn (array $bucket): array => [
                 'label' => $bucket['key_as_string'],
                 'value' => $bucket['cumulative']['value'] ?? null,

--- a/src/Analytics/Widgets/GroupedTrend.php
+++ b/src/Analytics/Widgets/GroupedTrend.php
@@ -25,7 +25,7 @@ class GroupedTrend extends Widget
         protected Metric $metric,
         protected string $field,
         protected string $groupBy,
-        protected CalendarInterval $interval,
+        protected CalendarInterval|string $interval,
         protected int $limit,
         protected ?string $timeZone = null,
     ) {
@@ -53,7 +53,7 @@ class GroupedTrend extends Widget
             'metric' => $this->metric->value,
             'field' => $this->field,
             'group_by' => $this->groupBy,
-            'interval' => $this->interval->name,
+            'interval' => $this->interval instanceof CalendarInterval ? $this->interval->name : $this->interval,
             'groups' => $groups->map(fn (array $group): array => [
                 'group' => $group['key'],
                 'series' => array_map(fn (array $bucket): array => [

--- a/src/Analytics/Widgets/Trend.php
+++ b/src/Analytics/Widgets/Trend.php
@@ -24,7 +24,7 @@ class Trend extends Widget
         string $dateFormat,
         protected Metric $metric,
         protected string $field,
-        protected CalendarInterval $interval,
+        protected CalendarInterval|string $interval,
         protected ?string $timeZone = null,
     ) {
         parent::__construct($name, $dateField, $from, $to, $dateFormat);
@@ -46,7 +46,7 @@ class Trend extends Widget
             'type' => 'trend',
             'metric' => $this->metric->value,
             'field' => $this->field,
-            'interval' => $this->interval->name,
+            'interval' => $this->interval instanceof CalendarInterval ? $this->interval->name : $this->interval,
             'series' => $buckets->map(fn (array $bucket): array => [
                 'label' => $bucket['key_as_string'],
                 'value' => $this->metric->extract($bucket['metric'] ?? []),

--- a/src/Query/Aggregations/Bucket/DateHistogram.php
+++ b/src/Query/Aggregations/Bucket/DateHistogram.php
@@ -14,7 +14,7 @@ class DateHistogram extends Bucket
     public function __construct(
         protected string $name,
         protected string $field,
-        protected CalendarInterval $interval,
+        protected CalendarInterval|string $interval,
         protected int $minDocCount = 0,
         protected ?array $extendedBounds = null,
         protected ?string $format = null,
@@ -23,10 +23,16 @@ class DateHistogram extends Bucket
 
     protected function value(): array
     {
+        // A CalendarInterval (1d, 1w, 1M…) is calendar-aware; a raw string (15d, 90m, 12h) is a
+        // fixed interval — Elasticsearch requires the latter for any multiple of a unit.
+        [$key, $interval] = $this->interval instanceof CalendarInterval
+            ? ['calendar_interval', $this->interval->value]
+            : ['fixed_interval', $this->interval];
+
         $value = [
             'date_histogram' => [
                 'field' => $this->field,
-                'calendar_interval' => $this->interval->value,
+                $key => $interval,
                 'min_doc_count' => $this->minDocCount,
             ],
         ];

--- a/src/Query/Aggs.php
+++ b/src/Query/Aggs.php
@@ -152,7 +152,7 @@ class Aggs implements AggsInterface
     public function dateHistogram(
         string $name,
         string $field,
-        CalendarInterval $interval,
+        CalendarInterval|string $interval,
         int $minDocCount = 0,
         ?array $extendedBounds = null,
         ?string $format = null,

--- a/tests/AggregationTest.php
+++ b/tests/AggregationTest.php
@@ -350,6 +350,34 @@ class AggregationTest extends TestCase
     /**
      * @test
      */
+    public function date_histogram_uses_calendar_interval_for_enum(): void
+    {
+        $aggs = new SearchAggregation;
+        $aggs->dateHistogram('timeline', 'created_at', CalendarInterval::Week);
+
+        $raw = $aggs->toRaw();
+
+        $this->assertSame('1w', $raw['timeline']['date_histogram']['calendar_interval']);
+        $this->assertArrayNotHasKey('fixed_interval', $raw['timeline']['date_histogram']);
+    }
+
+    /**
+     * @test
+     */
+    public function date_histogram_uses_fixed_interval_for_string(): void
+    {
+        $aggs = new SearchAggregation;
+        $aggs->dateHistogram('timeline', 'created_at', '15d');
+
+        $raw = $aggs->toRaw();
+
+        $this->assertSame('15d', $raw['timeline']['date_histogram']['fixed_interval']);
+        $this->assertArrayNotHasKey('calendar_interval', $raw['timeline']['date_histogram']);
+    }
+
+    /**
+     * @test
+     */
     public function ranges_aggregation(): void
     {
         $name = uniqid();


### PR DESCRIPTION
## Problem

`DateHistogram` only ever emitted `calendar_interval`. Elasticsearch restricts `calendar_interval` to a **single** unit (`1d`, `1w`, `1M`, `1y`…), so any multiple of a unit — `15d`, `90m`, `12h` — is rejected. There was no way to bucket a trend "every 15 days".

Multiples must use `fixed_interval` instead.

## Change

- **`DateHistogram`** now accepts `CalendarInterval|string`. A `CalendarInterval` enum still emits `calendar_interval` (no behavior change for existing callers); a raw string emits `fixed_interval`.
- Threaded `CalendarInterval|string` through `Aggs::dateHistogram`, the `Trend` / `Cumulative` / `GroupedTrend` widgets, and the `Analytics::trend|cumulative|groupedTrend` builder methods. The widgets' `extract()` reports the enum name for calendar intervals and the raw value (e.g. `15d`) for fixed ones.
- **`SigmieAnalyticsTool`** recognizes fixed intervals matching `^\d+(ms|s|m|h|d)$`, passes them straight through, and documents them in the tool description and the `interval` schema.

## Backward compatibility

Fully backward compatible — every existing call passes a `CalendarInterval` and keeps emitting `calendar_interval`. Only new string inputs take the `fixed_interval` path.

## Tests

Added `toRaw()` assertions in `tests/AggregationTest.php`:
- enum interval → `calendar_interval: 1w` (no `fixed_interval`)
- string interval → `fixed_interval: 15d` (no `calendar_interval`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)