### PR TITLE
Analytics: zero-fill trends across the full requested window

### DIFF
--- a/src/Analytics/Widgets/Cumulative.php
+++ b/src/Analytics/Widgets/Cumulative.php
@@ -33,7 +33,7 @@ class Cumulative extends Widget
     public function toRaw(): array
     {
         return $this->scoped($this->name, $this->from, $this->to, function (Aggs $aggs): void {
-            $aggs->dateHistogram('series', $this->dateField, $this->interval, timeZone: $this->timeZone)
+            $aggs->dateHistogram('series', $this->dateField, $this->interval, extendedBounds: $this->extendedBounds(), timeZone: $this->timeZone)
                 ->aggregate(function (Aggs $sub): void {
                     $this->metric->apply($sub, 'metric', $this->field);
                     $sub->cumulativeSum('cumulative', 'metric');

--- a/src/Analytics/Widgets/GroupedTrend.php
+++ b/src/Analytics/Widgets/GroupedTrend.php
@@ -38,7 +38,7 @@ class GroupedTrend extends Widget
             $aggs->terms('groups', $this->groupBy)
                 ->size($this->limit)
                 ->aggregate(function (Aggs $sub): void {
-                    $sub->dateHistogram('series', $this->dateField, $this->interval, timeZone: $this->timeZone)
+                    $sub->dateHistogram('series', $this->dateField, $this->interval, extendedBounds: $this->extendedBounds(), timeZone: $this->timeZone)
                         ->aggregate(fn (Aggs $m) => $this->metric->apply($m, 'metric', $this->field));
                 });
         })->toRaw();

--- a/src/Analytics/Widgets/Trend.php
+++ b/src/Analytics/Widgets/Trend.php
@@ -33,7 +33,7 @@ class Trend extends Widget
     public function toRaw(): array
     {
         return $this->scoped($this->name, $this->from, $this->to, function (Aggs $aggs): void {
-            $aggs->dateHistogram('series', $this->dateField, $this->interval, timeZone: $this->timeZone)
+            $aggs->dateHistogram('series', $this->dateField, $this->interval, extendedBounds: $this->extendedBounds(), timeZone: $this->timeZone)
                 ->aggregate(fn (Aggs $sub) => $this->metric->apply($sub, 'metric', $this->field));
         })->toRaw();
     }

--- a/src/Analytics/Widgets/Widget.php
+++ b/src/Analytics/Widgets/Widget.php
@@ -37,6 +37,22 @@ abstract class Widget implements ToRaw
     abstract public function extract(array $aggregations): array;
 
     /**
+     * Force a date histogram to span the FULL requested window [$from, $to), emitting zero-count
+     * buckets for periods with no data. Without this the histogram stops at the last bucket that
+     * has documents, so a query for a wide range (e.g. a full year over partial data) silently
+     * trims the empty tail instead of showing it. Epoch millis; max is exclusive-aware.
+     *
+     * @return array{min: int, max: int}
+     */
+    protected function extendedBounds(): array
+    {
+        return [
+            'min' => $this->from->getTimestamp() * 1000,
+            'max' => $this->to->getTimestamp() * 1000 - 1,
+        ];
+    }
+
+    /**
      * Wrap the inner aggregations in a `filter` bucket scoped to [$from, $to).
      */
     protected function scoped(

--- a/tests/AnalyticsTest.php
+++ b/tests/AnalyticsTest.php
@@ -441,4 +441,81 @@ class AnalyticsTest extends TestCase
         $this->assertSame('-1 month', Period::ThisMonth->previousModifier());
         $this->assertNull(Period::Last7Days->previousModifier());
     }
+
+    /**
+     * The sales index only has January data; a trend over Jan→Jun must still return a bucket per
+     * month, with the empty months (Feb–May) zero-filled — not trimmed at the last bucket with data.
+     *
+     * @test
+     */
+    public function trend_zero_fills_the_full_requested_window(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $result = $index->analytics('created_at')
+            ->from($this->date('2024-01-01'))
+            ->to($this->date('2024-06-01'))
+            ->trend('revenue', Metric::Sum, 'amount', CalendarInterval::Month)
+            ->get();
+
+        $series = $result['revenue']['series'];
+
+        $this->assertCount(5, $series); // Jan, Feb, Mar, Apr, May — not just January
+        $this->assertEquals(450.0, $series[0]['value']);
+        $this->assertEquals(0.0, $series[1]['value']);
+        $this->assertEquals(0.0, $series[2]['value']);
+        $this->assertEquals(0.0, $series[3]['value']);
+        $this->assertEquals(0.0, $series[4]['value']);
+    }
+
+    /**
+     * A cumulative curve over a wider-than-data window flattens across the empty tail instead of
+     * stopping in January.
+     *
+     * @test
+     */
+    public function cumulative_zero_fills_the_full_requested_window(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $result = $index->analytics('created_at')
+            ->from($this->date('2024-01-01'))
+            ->to($this->date('2024-06-01'))
+            ->cumulative('growth', Metric::Sum, 'amount', CalendarInterval::Month)
+            ->get();
+
+        $series = $result['growth']['series'];
+
+        $this->assertCount(5, $series);
+        $this->assertEquals(450.0, $series[0]['value']);
+        $this->assertEquals(450.0, $series[4]['value']); // running total holds across the empty months
+    }
+
+    /**
+     * Every group's series in a grouped trend spans the full window with zero-filled empty months.
+     *
+     * @test
+     */
+    public function grouped_trend_zero_fills_each_group_across_the_full_window(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $result = $index->analytics('created_at')
+            ->from($this->date('2024-01-01'))
+            ->to($this->date('2024-06-01'))
+            ->groupedTrend('by_product', Metric::Sum, 'amount', 'product', CalendarInterval::Month, 10)
+            ->get();
+
+        $groups = [];
+        foreach ($result['by_product']['groups'] as $group) {
+            $groups[$group['group']] = $group['series'];
+        }
+
+        $this->assertCount(5, $groups['A']);
+        $this->assertCount(5, $groups['B']);
+        $this->assertEquals(370.0, $groups['A'][0]['value']);
+        $this->assertEquals(80.0, $groups['B'][0]['value']);
+        $this->assertEquals(0.0, $groups['A'][4]['value']);
+        $this->assertEquals(0.0, $groups['B'][4]['value']);
+    }
 }


### PR DESCRIPTION
## What

Time-bucketed analytics widgets (`Trend`, `Cumulative`, `GroupedTrend`) now pass `extended_bounds` = `[from, to)` to the date histogram, so a trend spans the **full requested window** and periods with no data render as **zero buckets** instead of being trimmed.

## Why

Today the date histogram stops at the last bucket that has documents. So a query over a wide range with partial data — e.g. "revenue across 2018" when orders only run through May — silently drops Jun–Dec instead of showing the empty tail. That makes a partial dataset look like the whole period, and lets consumers narrate non-existent "recoveries".

## How

The engine already supports `extendedBounds` + `min_doc_count: 0` on `DateHistogram` — this just wires it through. A shared `Widget::extendedBounds()` helper returns `['min' => from, 'max' => to-1ms]` (epoch millis, exclusive-aware), and the three time-bucketed widgets pass it.

No API change; `min_doc_count` already defaults to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)