### PR TITLE
feat(analytics): table, funnel, stats, heatmap, retention & geo widgets + per-widget windows

### DIFF
--- a/docs/aggregations.md
+++ b/docs/aggregations.md
@@ -1,6 +1,6 @@
 ---
 title: Aggregations
-short_description: Run Elasticsearch metric and bucket aggregations with Sigmie — sum, avg, stats, terms, histogram, date histogram, and pipeline aggregations.
+short_description: Run Elasticsearch metric and bucket aggregations with Sigmie — sum, avg, stats, terms, histogram, date histogram, geohash grid, and pipeline aggregations.
 keywords: [aggregations, facets, analytics, bucket aggregations, metrics]
 category: Features
 order: 2
@@ -151,6 +151,14 @@ Let Elasticsearch pick the bucket interval:
 
 ```php
 $agg->autoDateHistogram(name: 'timeline', field: 'created_at', buckets: 12);
+```
+
+### Geohash grid
+
+Bucket a `geo_point` field into geohash cells — the basis of a map heatmap. Higher `precision` (1–12) means smaller, more granular cells; `size` caps the number of returned cells:
+
+```php
+$agg->geoHashGrid(name: 'areas', field: 'location', precision: 5);
 ```
 
 ## Sub-aggregations

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -294,15 +294,20 @@ $orders->analytics('created_at')
 
 ### Per-widget window
 
-`from()` / `to()` set one window for the whole dashboard. To give a single widget its **own** window — an all-time headline next to a last-30-days trend — chain `->over($from, $to)` straight after it. Like the per-widget `filter:`, it scopes that one widget only, so the mixed-window dashboard stays a single request:
+`from()` / `to()` set one window for the whole dashboard. To give a single widget its **own** window — an all-time headline next to a last-30-days trend — pass a `window:` to the widget. Like the per-widget `filter:`, it scopes that one widget only, so the mixed-window dashboard stays a single request. It accepts a named [`Period`](#named-ranges) or a `[$from, $to]` pair:
 
 ```php
+use Sigmie\Analytics\Enums\Period;
+
 $orders->analytics('created_at')
     ->from($last30Start)->to($now)
-    ->kpi('lifetime_revenue', Metric::Sum, 'amount')->over($accountStart, $now)   // all-time
-    ->trend('recent_revenue', Metric::Sum, 'amount', CalendarInterval::Day)       // last 30 days
+    ->kpi('lifetime_revenue', Metric::Sum, 'amount', window: [$accountStart, $now])  // all-time
+    ->kpi('this_year', Metric::Sum, 'amount', window: Period::ThisYear)               // named period
+    ->trend('recent_revenue', Metric::Sum, 'amount', CalendarInterval::Day)           // dashboard window
     ->get();
 ```
+
+`window:` is the last argument of every widget method, alongside `filter:`. A `kpiDelta` with a custom `window:` compares against the immediately preceding equal-length window (the named-period comparison only applies to the dashboard-wide `range()`).
 
 ## Timezone
 
@@ -360,7 +365,7 @@ $dashboard = $analytics->formatResponse($metrics);            // widget name => 
 
 ## Analytics for AI agents
 
-Add [`AsTool`](laravel-ai.md) to an index and its `tools()` suite includes an `analytics` tool. The agent picks a `widget` and arguments; "give me sales this month as a chart" becomes a `trend` call, and "show it per month instead" is the **same call with `interval: month`** — the agent adapts one argument and re-runs.
+Add [`AsTool`](laravel-ai.md) to an index and its `tools()` suite includes an `analytics` tool. The agent picks a `widget` — `kpi`, `kpi_delta`, `trend`, `cumulative`, `grouped_trend`, `breakdown`, `distribution`, `percentiles`, `stats`, `table`, `funnel`, `heatmap`, `retention` or `geo` — and arguments; "give me sales this month as a chart" becomes a `trend` call, and "show it per month instead" is the **same call with `interval: month`** — the agent adapts one argument and re-runs. The tool's description carries a grounded example per widget (using the index's own fields), so the model sees the exact argument shape each one expects.
 
 ```php
 class OrderIndex extends SigmieIndex

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -343,25 +343,32 @@ A **calendar** range also makes `kpiDelta` compare against the *previous instanc
 
 `get()` already runs every widget in a single request. But a dashboard often needs **one more** query that can't be expressed as an aggregation — most commonly a paginated, field-collapsed [`search()`](search.md) for a results table (`top_hits` only returns the top N of one bucket). Rather than pay a second round-trip, batch both into one `_msearch`.
 
-`toSearch()` returns the whole dashboard as a single query you can hand to [`newMultiSearch()`](search.md). Run the batch, then turn the dashboard's response slot back into widget results with `formatResponse()`:
+`newAnalytics()` starts a dashboard **inside** the multi-search — compose widgets on it as usual, and its response slot comes back already mapped to the widget result map:
 
 ```php
-$analytics = $orders->analytics('created_at')
+$multi = $sigmie->newMultiSearch();
+
+$multi->newAnalytics($orders, 'created_at', 'metrics')        // the whole dashboard
     ->from($start)->to($end)
     ->kpiDelta('revenue', Metric::Sum, 'amount')
     ->trend('revenue_over_time', Metric::Sum, 'amount', CalendarInterval::Day);
 
-$multi = $sigmie->newMultiSearch();
-$multi->addQuery($analytics->toSearch(), 'metrics');          // the whole dashboard
 $multi->newSearch($orders->name(), 'rows')                    // a paginated rows table
     ->queryString('')->filters("status:'paid'")->page(3, 20);
 
 [$metrics, $rows] = $multi->get();                            // one HTTP round-trip
-
-$dashboard = $analytics->formatResponse($metrics);            // widget name => result
+// $metrics is already the widget name => result map
 ```
 
-`addQuery()` adds a prebuilt query to the batch (the counterpart to `add()` for a `NewSearch`); `formatResponse()` maps the raw response's aggregations through every widget, exactly as `get()` does internally. Use `get()` for a standalone dashboard, `toSearch()` + `formatResponse()` when it shares a request with another query.
+If you built the `Analytics` elsewhere, add it to the batch with `toSearch()` instead, then map its slot by hand with `formatResponse()`:
+
+```php
+$multi->addQuery($analytics->toSearch(), 'metrics');
+[$metrics, $rows] = $multi->get();
+$dashboard = $analytics->formatResponse($metrics);
+```
+
+`formatResponse()` maps the raw response's aggregations through every widget, exactly as `get()` does internally. Use `get()` for a standalone dashboard, and `newAnalytics()` (or `toSearch()` + `formatResponse()`) when it shares a request with another query.
 
 ## Analytics for AI agents
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,7 +1,7 @@
 ---
 title: Analytics
-short_description: Build dashboard analytics on a Sigmie index — KPIs, period-over-period deltas, time-series trends, breakdowns, distributions, percentiles, and cumulative growth — and expose them to AI agents.
-keywords: [analytics, dashboard, trends, KPI, time series, breakdown, histogram, percentiles, AI agent]
+short_description: Build dashboard analytics on a Sigmie index — KPIs, period-over-period deltas, time-series trends, breakdowns, distributions, percentiles, cumulative growth, funnels, cohort retention, heatmaps, geo maps and document tables — and expose them to AI agents.
+keywords: [analytics, dashboard, trends, KPI, time series, breakdown, histogram, percentiles, funnel, retention, cohort, heatmap, geo, table, multi-search, AI agent]
 category: Features
 order: 3
 related_pages: [aggregations, facets, laravel-ai]
@@ -152,6 +152,102 @@ $orders->analytics('created_at')
 // ]]]
 ```
 
+### Stats — the five-number summary
+
+`count`, `min`, `max`, `avg` and `sum` of a numeric field in one tile, built on the `stats` aggregation.
+
+```php
+$orders->analytics('created_at')
+    ->stats('order_size', 'amount')
+    ->get();
+
+// ['order_size' => ['type' => 'stats', 'count' => 5, 'min' => 30.0, 'max' => 200.0, 'avg' => 90.0, 'sum' => 450.0]]
+```
+
+### Table — the documents behind a number
+
+Every widget so far returns an aggregated number. `table` returns the **actual matching documents** — the rows behind a slice ("the 20 most recent orders", "the latest errors") — via a `top_hits` aggregation, so it scopes to the same window and per-widget `filter:` as the rest. `fields` limits the returned source (omit for the full document); `sort` is a `"field:dir"` string (defaults to descending).
+
+```php
+$orders->analytics('created_at')
+    ->table('recent', fields: ['amount', 'product'], limit: 20, sort: 'amount:desc')
+    ->get();
+
+// ['recent' => ['type' => 'table', 'rows' => [
+//     ['id' => 'ord_8f2c…', 'document' => ['amount' => 200, 'product' => 'A']], ...
+// ]]]
+```
+
+`top_hits` returns the top N of one bucket — it is **not** a paginated, field-collapsed search. For an interactive table with deep pagination use a regular [`search()`](search.md); to batch that search into the same request as the dashboard, see [multi-search](#one-request-with-multi-search) below.
+
+### Funnel — ordered step conversion
+
+How many documents reach each stage and the conversion between them ("visited → signed up → paid"). `steps` is an **ordered** map of `label => slice`, where each slice is a [filter-parser](filter-parser.md) string or a query object. Each step reports its `count`, its `conversion` against the first step, and its `step_conversion` against the previous step.
+
+```php
+$events->analytics('created_at')
+    ->funnel('signup', [
+        'visited' => "event:'visit'",
+        'signed'  => "event:'signup'",
+        'paid'    => "event:'paid'",
+    ])
+    ->get();
+
+// ['signup' => ['type' => 'funnel', 'steps' => [
+//     ['label' => 'visited', 'count' => 4, 'conversion' => 1.0,  'step_conversion' => 1.0],
+//     ['label' => 'signed',  'count' => 2, 'conversion' => 0.5,  'step_conversion' => 0.5],
+//     ['label' => 'paid',    'count' => 1, 'conversion' => 0.25, 'step_conversion' => 0.5],
+// ]]]
+```
+
+### Heatmap — one dimension by another
+
+A two-dimensional matrix — `rowField` × `colField`, each cell carrying a metric (defaults to a count). Built on nested `terms` buckets.
+
+```php
+$orders->analytics('created_at')
+    ->heatmap('by_region', rowField: 'region', colField: 'device', metric: Metric::Sum, field: 'amount')
+    ->get();
+
+// ['by_region' => ['type' => 'heatmap', 'rows' => [
+//     ['key' => 'US', 'count' => 3, 'cells' => [
+//         ['key' => 'mobile', 'value' => 220.0, 'count' => 2],
+//         ['key' => 'desktop', 'value' => 90.0, 'count' => 1],
+//     ]], ...
+// ]]]
+```
+
+### Retention — a cohort grid
+
+Entities (identified by `idField`) grouped by the period of their `cohortField` date, then counted **distinct** across each later period of the timeline — the classic triangular cohort table. Built on a `date_histogram` of the cohort field, a nested `date_histogram` of the timeline, and a `cardinality` of the id.
+
+```php
+$signups->analytics('active_at')
+    ->retention('cohorts', cohortField: 'signup_at', idField: 'user_id', interval: CalendarInterval::Week)
+    ->get();
+
+// ['cohorts' => ['type' => 'retention', 'cohorts' => [
+//     ['cohort' => '2024-01-01...', 'size' => 2, 'periods' => [
+//         ['label' => '2024-01-01...', 'value' => 2],
+//         ['label' => '2024-01-02...', 'value' => 1],
+//     ]], ...
+// ]]]
+```
+
+### Geo — a map heatmap
+
+A metric bucketed into geohash cells of a `geo_point` field, for a map overlay. Higher `precision` means smaller, more granular cells. Built on the `geohash_grid` aggregation.
+
+```php
+$orders->analytics('created_at')
+    ->geo('areas', 'location', precision: 5)
+    ->get();
+
+// ['areas' => ['type' => 'geo', 'precision' => 5, 'buckets' => [
+//     ['geohash' => 'u173z', 'value' => 2, 'count' => 2], ...
+// ]]]
+```
+
 ## Filtering and the time window
 
 `filters()` accepts the same [filter-parser](filter-parser.md) DSL as search, applied across every widget. `filterQuery()` ANDs a hard query clause (a query object) into the same filter context — exactly like [`NewSearch::filterQuery()`](search.md):
@@ -196,6 +292,18 @@ $orders->analytics('created_at')
     ->get();
 ```
 
+### Per-widget window
+
+`from()` / `to()` set one window for the whole dashboard. To give a single widget its **own** window — an all-time headline next to a last-30-days trend — chain `->over($from, $to)` straight after it. Like the per-widget `filter:`, it scopes that one widget only, so the mixed-window dashboard stays a single request:
+
+```php
+$orders->analytics('created_at')
+    ->from($last30Start)->to($now)
+    ->kpi('lifetime_revenue', Metric::Sum, 'amount')->over($accountStart, $now)   // all-time
+    ->trend('recent_revenue', Metric::Sum, 'amount', CalendarInterval::Day)       // last 30 days
+    ->get();
+```
+
 ## Timezone
 
 Analytics is UTC by default — which silently mis-buckets daily/weekly/monthly charts for users elsewhere (a Tokyo sale just after local midnight lands in the previous UTC day). Set the timezone and Elasticsearch aligns bucket boundaries to local time and handles DST:
@@ -225,6 +333,30 @@ $orders->analytics('created_at')->timezoneOffset(540)->range(Period::Last7Days);
 `Today, Yesterday, ThisWeek, LastWeek, ThisMonth, LastMonth, ThisQuarter, LastQuarter, ThisYear, LastYear, Last7Days, Last30Days, Last90Days`.
 
 A **calendar** range also makes `kpiDelta` compare against the *previous instance* of that period rather than an equal-length window — `ThisMonth` → vs last calendar month, `ThisWeek` → vs last week. Raw `from()`/`to()` keep the equal-duration comparison.
+
+## One request with multi-search
+
+`get()` already runs every widget in a single request. But a dashboard often needs **one more** query that can't be expressed as an aggregation — most commonly a paginated, field-collapsed [`search()`](search.md) for a results table (`top_hits` only returns the top N of one bucket). Rather than pay a second round-trip, batch both into one `_msearch`.
+
+`toSearch()` returns the whole dashboard as a single query you can hand to [`newMultiSearch()`](search.md). Run the batch, then turn the dashboard's response slot back into widget results with `formatResponse()`:
+
+```php
+$analytics = $orders->analytics('created_at')
+    ->from($start)->to($end)
+    ->kpiDelta('revenue', Metric::Sum, 'amount')
+    ->trend('revenue_over_time', Metric::Sum, 'amount', CalendarInterval::Day);
+
+$multi = $sigmie->newMultiSearch();
+$multi->addQuery($analytics->toSearch(), 'metrics');          // the whole dashboard
+$multi->newSearch($orders->name(), 'rows')                    // a paginated rows table
+    ->queryString('')->filters("status:'paid'")->page(3, 20);
+
+[$metrics, $rows] = $multi->get();                            // one HTTP round-trip
+
+$dashboard = $analytics->formatResponse($metrics);            // widget name => result
+```
+
+`addQuery()` adds a prebuilt query to the batch (the counterpart to `add()` for a `NewSearch`); `formatResponse()` maps the raw response's aggregations through every widget, exactly as `get()` does internally. Use `get()` for a standalone dashboard, `toSearch()` + `formatResponse()` when it shares a request with another query.
 
 ## Analytics for AI agents
 

--- a/src/AI/SigmieAnalyticsTool.php
+++ b/src/AI/SigmieAnalyticsTool.php
@@ -21,9 +21,10 @@ use Sigmie\SigmieIndex;
  *
  * One tool, many widget shapes (selected by `widget`): a KPI number, a KPI with a
  * period-over-period delta, a time-series trend, a stacked/grouped trend, a top-N breakdown,
- * a value distribution, a cumulative growth curve, and percentiles. The agent adapts a chart
- * by re-calling with different arguments — "per day → per month" is the same call with a
- * different `interval`.
+ * a value distribution, a cumulative growth curve, percentiles, a five-number stats summary,
+ * a table of the actual documents, an ordered funnel, a two-dimension heatmap, a cohort
+ * retention grid, and a geo (geohash) map. The agent adapts a chart by re-calling with
+ * different arguments — "per day → per month" is the same call with a different `interval`.
  *
  * Requires `laravel/ai` to be installed.
  *
@@ -53,6 +54,8 @@ class SigmieAnalyticsTool implements Tool
     {
         $dateFields = $this->fieldNamesOfTypes(['date']);
         $numericFields = $this->fieldNamesOfTypes(['number']);
+        $keywordFields = $this->fieldNamesOfTypes(['keyword', 'text']);
+        $geoFields = $this->fieldNamesOfTypes(['geo']);
 
         $description = sprintf("Dashboard analytics for the '%s' index — compute a single chart/widget per call.", $this->index->name());
 
@@ -64,7 +67,13 @@ class SigmieAnalyticsTool implements Tool
             ."- grouped_trend: one trend line per value of group_by — stacked chart (needs metric, field, group_by, interval)\n"
             ."- breakdown: top-N group_by values ranked by a metric (needs group_by, metric, field)\n"
             ."- distribution: histogram of a numeric field (needs field, bucket_size)\n"
-            .'- percentiles: p50/p75/p95/p99 of a numeric field (needs field)';
+            ."- percentiles: p50/p75/p95/p99 of a numeric field (needs field)\n"
+            ."- stats: count/min/max/avg/sum of a numeric field in one tile (needs field)\n"
+            ."- table: the actual matching documents — the rows behind a number, not a metric (needs fields, sort, limit)\n"
+            ."- funnel: ordered step conversion with drop-off % (needs steps)\n"
+            ."- heatmap: a row_field × col_field matrix, a metric per cell (needs row_field, col_field; metric+field optional, defaults to count)\n"
+            ."- retention: cohort grid — entities by cohort period, counted distinct per later period (needs cohort_field, id_field, interval)\n"
+            .'- geo: a count bucketed into geohash cells of a geo_point field — a map heatmap (needs field, precision)';
 
         // Phrasing → widget hints. Disambiguates the common trap where 'monthly/weekly/daily X
         // over <period>' reads as 'one number for the period' (kpi) instead of 'a series bucketed
@@ -77,7 +86,13 @@ class SigmieAnalyticsTool implements Tool
             ."- \"top N <thing> by X\", \"best <thing>\", \"which <thing> drove the most X\" → breakdown (group_by=<thing>)\n"
             ."- \"X this month\" / \"average X last week\" with no bucket word → kpi (or kpi_delta when the user compares to a prior period)\n"
             ."- \"distribution of X\", \"histogram of X\" → distribution\n"
-            .'- "p50/p75/p95/p99", "percentiles of X", "median X" → percentiles';
+            ."- \"p50/p75/p95/p99\", \"percentiles of X\", \"median X\" → percentiles\n"
+            ."- \"summary of X\", \"min/max/avg of X\", \"stats for X\" → stats\n"
+            ."- \"show/list the actual <docs>\", \"recent <docs>\", \"the rows behind X\", \"examples of X\" → table\n"
+            ."- \"funnel\", \"conversion from A → B → C\", \"drop-off between steps\" → funnel (steps in order)\n"
+            ."- \"A by B\", \"<dim1> vs <dim2>\", \"a matrix/heatmap of A and B\" → heatmap (row_field=A, col_field=B)\n"
+            ."- \"retention\", \"cohort analysis\", \"how many users come back\" → retention\n"
+            .'- "on a map", "by location / area / region (coordinates)", "geo heatmap" → geo';
 
         $description .= "\n\nMetrics (`metric`): sum, avg, min, max, count, unique (distinct), median.";
         $description .= "\n\nIntervals (`interval`): a calendar unit (minute, hour, day, week, month, quarter, year) or a fixed interval — a multiple of a unit like 15d, 12h, 90m, 30s.";
@@ -89,6 +104,12 @@ class SigmieAnalyticsTool implements Tool
         );
         $description .= "\nNumeric fields for `field`: ".(
             $numericFields !== [] ? implode(', ', $numericFields) : '(none)'
+        );
+        $description .= "\nKeyword fields for `group_by` / `row_field` / `col_field` / `id_field`: ".(
+            $keywordFields !== [] ? implode(', ', $keywordFields) : '(none)'
+        );
+        $description .= "\nGeo fields for `field` (geo widget): ".(
+            $geoFields !== [] ? implode(', ', $geoFields) : '(none — this index has no geo_point field)'
         );
 
         $description .= "\n\nTime window: `from` and `to` are ISO dates (default: last 30 days).\n"
@@ -109,6 +130,8 @@ class SigmieAnalyticsTool implements Tool
         $number = $this->fieldNamesOfTypes(['number'])[0] ?? '<numeric_field>';
         // group_by is typically a keyword or a category (a text field with a keyword sub-field).
         $keyword = $this->fieldNamesOfTypes(['keyword', 'text'])[0] ?? '<keyword_field>';
+        $keyword2 = $this->fieldNamesOfTypes(['keyword', 'text'])[1] ?? $keyword;
+        $geo = $this->fieldNamesOfTypes(['geo'])[0] ?? '<geo_point_field>';
 
         $examples = [
             'total for the month' => ['widget' => 'kpi', 'date_field' => $date, 'metric' => 'sum', 'field' => $number, 'range' => 'this_month'],
@@ -119,6 +142,12 @@ class SigmieAnalyticsTool implements Tool
             'top 5 groups by total' => ['widget' => 'breakdown', 'date_field' => $date, 'group_by' => $keyword, 'metric' => 'sum', 'field' => $number, 'limit' => 5, 'range' => 'this_month'],
             'histogram of a number' => ['widget' => 'distribution', 'date_field' => $date, 'field' => $number, 'bucket_size' => 100, 'range' => 'this_month'],
             'p50/p95/p99 of a number' => ['widget' => 'percentiles', 'date_field' => $date, 'field' => $number, 'percents' => '50,95,99', 'range' => 'this_month'],
+            'summary of a number' => ['widget' => 'stats', 'date_field' => $date, 'field' => $number, 'range' => 'this_month'],
+            'the 20 biggest rows' => ['widget' => 'table', 'date_field' => $date, 'fields' => sprintf('%s,%s', $keyword, $number), 'sort' => $number.':desc', 'limit' => 20, 'range' => 'this_month'],
+            'conversion funnel' => ['widget' => 'funnel', 'date_field' => $date, 'steps' => sprintf('[{"label":"all","filter":"%s:\'a\'"},{"label":"converted","filter":"%s:\'b\'"}]', $keyword, $keyword), 'range' => 'this_month'],
+            'matrix of two dimensions' => ['widget' => 'heatmap', 'date_field' => $date, 'row_field' => $keyword, 'col_field' => $keyword2, 'metric' => 'sum', 'field' => $number, 'range' => 'this_month'],
+            'weekly cohort retention' => ['widget' => 'retention', 'date_field' => $date, 'cohort_field' => $date, 'id_field' => $keyword, 'interval' => 'week', 'range' => 'last_90_days'],
+            'counts on a map' => ['widget' => 'geo', 'date_field' => $date, 'field' => $geo, 'precision' => 5, 'range' => 'this_month'],
             'one slice of the window' => ['widget' => 'kpi', 'date_field' => $date, 'metric' => 'sum', 'field' => $number, 'filters' => sprintf("%s:'…'", $keyword), 'range' => 'this_month'],
         ];
 
@@ -136,20 +165,28 @@ class SigmieAnalyticsTool implements Tool
         // `widget` and `date_field` are plain required; every optional param is `nullable()->required()`
         // so the schema stays valid under OpenAI's strict function-calling (callers pass null to omit).
         return [
-            'widget' => $schema->string()->description('kpi | kpi_delta | trend | cumulative | grouped_trend | breakdown | distribution | percentiles')->required(),
+            'widget' => $schema->string()->description('kpi | kpi_delta | trend | cumulative | grouped_trend | breakdown | distribution | percentiles | stats | table | funnel | heatmap | retention | geo')->required(),
             'date_field' => $schema->string()->description('Timeline (date) field to bucket/scope by')->required(),
-            'metric' => $schema->string()->description('sum | avg | min | max | count | unique | median (pass null for distribution/percentiles)')->nullable()->required(),
-            'field' => $schema->string()->description('Numeric field the metric is computed on (pass null for count)')->nullable()->required(),
-            'interval' => $schema->string()->description('Time bucket for trends: a calendar unit (minute | hour | day | week | month | quarter | year) or a fixed interval like 15d | 12h | 90m (default day)')->default('day')->nullable()->required(),
+            'metric' => $schema->string()->description('sum | avg | min | max | count | unique | median (pass null for distribution, percentiles, stats, table, funnel, retention, geo; optional for heatmap — defaults to count)')->nullable()->required(),
+            'field' => $schema->string()->description('Numeric field the metric is computed on; also the numeric field for stats and the geo_point field for the geo widget (pass null for count)')->nullable()->required(),
+            'interval' => $schema->string()->description('Time bucket for trends and retention: a calendar unit (minute | hour | day | week | month | quarter | year) or a fixed interval like 15d | 12h | 90m (default day)')->default('day')->nullable()->required(),
             'group_by' => $schema->string()->description('Keyword field to group/break down by, for breakdown and grouped_trend (pass null otherwise)')->nullable()->required(),
-            'limit' => $schema->integer()->description('Max groups for breakdown/grouped_trend (default 10)')->default(10)->nullable()->required(),
+            'limit' => $schema->integer()->description('Max groups for breakdown/grouped_trend, rows for table, or cells per axis for heatmap (default 10)')->default(10)->nullable()->required(),
             'bucket_size' => $schema->integer()->description('Bucket width for the distribution widget (pass null otherwise)')->nullable()->required(),
             'percents' => $schema->string()->description('Comma-separated percentiles for the percentiles widget, e.g. "50,75,95,99" (pass null for the default)')->nullable()->required(),
+            'fields' => $schema->string()->description('Comma-separated source fields to return for the table widget, e.g. "id,amount" (pass null for the full document)')->nullable()->required(),
+            'sort' => $schema->string()->description('Sort for the table widget as "field:dir", e.g. "amount:desc" (pass null for default descending)')->nullable()->required(),
+            'steps' => $schema->string()->description('Funnel steps as an ORDERED JSON array of {label, filter} objects, e.g. [{"label":"visited","filter":"event:\'visit\'"},{"label":"paid","filter":"event:\'paid\'"}] (pass null otherwise)')->nullable()->required(),
+            'row_field' => $schema->string()->description('Heatmap row dimension — a keyword field (pass null otherwise)')->nullable()->required(),
+            'col_field' => $schema->string()->description('Heatmap column dimension — a keyword field (pass null otherwise)')->nullable()->required(),
+            'cohort_field' => $schema->string()->description('Retention cohort date field — entities are grouped by the period of this date (pass null otherwise)')->nullable()->required(),
+            'id_field' => $schema->string()->description('Retention entity id — a keyword field counted distinct per period (pass null otherwise)')->nullable()->required(),
+            'precision' => $schema->integer()->description('Geohash precision for the geo widget, 1 (coarse) to 12 (fine), default 5 (pass null otherwise)')->default(5)->nullable()->required(),
             'range' => $schema->string()->description('Named relative window, e.g. this_month | last_7_days (pass null to use from/to)')->nullable()->required(),
             'timezone_offset' => $schema->integer()->description('Timezone as minutes east of UTC, e.g. 540 for Tokyo (pass null for UTC)')->nullable()->required(),
             'from' => $schema->string()->description('ISO start date, inclusive — ignored when range is set (pass null for 30 days ago)')->nullable()->required(),
             'to' => $schema->string()->description('ISO end date, exclusive — ignored when range is set (pass null for now)')->nullable()->required(),
-            'filters' => $schema->string()->description('Filter expression, same DSL as the search tool — scopes this widget to a slice of the window; for a funnel or A-vs-B, call once per slice with a different filter (pass null for none)')->nullable()->required(),
+            'filters' => $schema->string()->description('Filter expression, same DSL as the search tool — scopes this widget to a slice of the window (pass null for none)')->nullable()->required(),
         ];
     }
 
@@ -211,7 +248,13 @@ class SigmieAnalyticsTool implements Tool
             'breakdown' => $analytics->breakdown('result', $groupBy(), $metric(), $field, $limit),
             'distribution' => $analytics->distribution('result', $this->required($request, 'field'), (int) ($request['bucket_size'] ?? throw new InvalidArgumentException('The distribution widget requires bucket_size.'))),
             'percentiles' => $analytics->percentiles('result', $this->required($request, 'field'), $this->percents($request)),
-            default => throw new InvalidArgumentException(sprintf("Unknown widget '%s'. Use one of: kpi, kpi_delta, trend, cumulative, grouped_trend, breakdown, distribution, percentiles.", $widget)),
+            'stats' => $analytics->stats('result', $this->required($request, 'field')),
+            'table' => $analytics->table('result', $this->csvList($request, 'fields'), $limit, $this->optional($request, 'sort')),
+            'funnel' => $analytics->funnel('result', $this->steps($request)),
+            'heatmap' => $analytics->heatmap('result', $this->required($request, 'row_field'), $this->required($request, 'col_field'), $this->metricOrCount($request), $field, $limit, $limit),
+            'retention' => $analytics->retention('result', $this->required($request, 'cohort_field'), $this->required($request, 'id_field'), $interval()),
+            'geo' => $analytics->geo('result', $this->required($request, 'field'), max(1, (int) ($request['precision'] ?? 5))),
+            default => throw new InvalidArgumentException(sprintf("Unknown widget '%s'. Use one of: kpi, kpi_delta, trend, cumulative, grouped_trend, breakdown, distribution, percentiles, stats, table, funnel, heatmap, retention, geo.", $widget)),
         };
     }
 
@@ -280,6 +323,74 @@ class SigmieAnalyticsTool implements Tool
             static fn (string $p): float => (float) trim($p),
             explode(',', $raw)
         ), static fn (float $p): bool => $p > 0 && $p < 100));
+    }
+
+    /**
+     * The metric for widgets where it is optional (heatmap), defaulting to Count when omitted.
+     */
+    protected function metricOrCount(Request $request): Metric
+    {
+        $metric = trim((string) ($request['metric'] ?? ''));
+
+        return $metric === '' ? Metric::Count : $this->metric($metric);
+    }
+
+    /**
+     * Ordered funnel steps from a JSON array of {label, filter} objects into a label => filter map.
+     *
+     * @return array<string, string>
+     */
+    protected function steps(Request $request): array
+    {
+        $raw = trim((string) ($request['steps'] ?? ''));
+
+        $raw !== '' || throw new InvalidArgumentException('The funnel widget requires steps — a JSON array of {label, filter} objects, in order.');
+
+        $decoded = json_decode($raw, true);
+
+        is_array($decoded) || throw new InvalidArgumentException('funnel steps must be a JSON array of {label, filter} objects, e.g. [{"label":"visited","filter":"event:\'visit\'"}].');
+
+        $steps = [];
+
+        foreach ($decoded as $step) {
+            $label = trim((string) ($step['label'] ?? ''));
+            $filter = trim((string) ($step['filter'] ?? ''));
+
+            ($label !== '' && $filter !== '') || throw new InvalidArgumentException('Each funnel step needs a non-empty label and filter.');
+
+            $steps[$label] = $filter;
+        }
+
+        return $steps !== [] ? $steps : throw new InvalidArgumentException('The funnel widget requires at least one step.');
+    }
+
+    /**
+     * A comma-separated argument parsed into a trimmed list (empty when absent).
+     *
+     * @return list<string>
+     */
+    protected function csvList(Request $request, string $key): array
+    {
+        $raw = trim((string) ($request[$key] ?? ''));
+
+        if ($raw === '') {
+            return [];
+        }
+
+        return array_values(array_filter(
+            array_map(static fn (string $v): string => trim($v), explode(',', $raw)),
+            static fn (string $v): bool => $v !== '',
+        ));
+    }
+
+    /**
+     * An optional string argument: the trimmed value, or null when absent.
+     */
+    protected function optional(Request $request, string $key): ?string
+    {
+        $value = trim((string) ($request[$key] ?? ''));
+
+        return $value !== '' ? $value : null;
     }
 
     protected function date(mixed $value): ?DateTimeInterface

--- a/src/AI/SigmieAnalyticsTool.php
+++ b/src/AI/SigmieAnalyticsTool.php
@@ -344,11 +344,15 @@ class SigmieAnalyticsTool implements Tool
     {
         $raw = trim((string) ($request['steps'] ?? ''));
 
-        $raw !== '' || throw new InvalidArgumentException('The funnel widget requires steps — a JSON array of {label, filter} objects, in order.');
+        if ($raw === '') {
+            throw new InvalidArgumentException('The funnel widget requires steps — a JSON array of {label, filter} objects, in order.');
+        }
 
         $decoded = json_decode($raw, true);
 
-        is_array($decoded) || throw new InvalidArgumentException('funnel steps must be a JSON array of {label, filter} objects, e.g. [{"label":"visited","filter":"event:\'visit\'"}].');
+        if (! is_array($decoded)) {
+            throw new InvalidArgumentException('funnel steps must be a JSON array of {label, filter} objects, e.g. [{"label":"visited","filter":"event:\'visit\'"}].');
+        }
 
         $steps = [];
 
@@ -356,7 +360,9 @@ class SigmieAnalyticsTool implements Tool
             $label = trim((string) ($step['label'] ?? ''));
             $filter = trim((string) ($step['filter'] ?? ''));
 
-            ($label !== '' && $filter !== '') || throw new InvalidArgumentException('Each funnel step needs a non-empty label and filter.');
+            if (! ($label !== '' && $filter !== '')) {
+                throw new InvalidArgumentException('Each funnel step needs a non-empty label and filter.');
+            }
 
             $steps[$label] = $filter;
         }

--- a/src/AI/SigmieAnalyticsTool.php
+++ b/src/AI/SigmieAnalyticsTool.php
@@ -114,7 +114,7 @@ class SigmieAnalyticsTool implements Tool
 
         $description .= "\n\nTime window: `from` and `to` are ISO dates (default: last 30 days).\n"
             ."Narrow with `filters` (same DSL as the search tool, e.g. \"status:'paid' AND amount>10\") — it scopes this widget to that slice of the window. Call describe_index for the full field list and filter syntax.\n"
-            .'Comparing slices (a funnel like total → engaged → completed, or A vs B): call this tool once per slice over the SAME window — each call narrows with its own `filters` — and read the numbers side by side.';
+            .'Comparing slices: for an ordered funnel (total → engaged → completed) use the funnel widget with `steps`; for an ad-hoc A vs B, call this tool once per slice over the SAME window — each call narrows with its own `filters` — and read the numbers side by side.';
 
         return $description."\n\nExamples (`widget` → arguments):\n".$this->examples();
     }

--- a/src/Analytics/Analytics.php
+++ b/src/Analytics/Analytics.php
@@ -8,7 +8,6 @@ use DateInterval;
 use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
-use LogicException;
 use Sigmie\Analytics\Enums\Metric;
 use Sigmie\Analytics\Enums\Period;
 use Sigmie\Analytics\Widgets\Breakdown;
@@ -75,8 +74,6 @@ class Analytics
     protected ?string $timeZone = null;
 
     protected ?Period $period = null;
-
-    protected ?string $lastWidget = null;
 
     protected ?Search $compiledSearch = null;
 
@@ -185,51 +182,68 @@ class Analytics
     /**
      * Add a KPI widget. An optional per-widget $filter — a filter-DSL string ("status:'paid'") or a
      * query object — restricts this KPI to its own slice of the window, so a single query can hold a
-     * whole funnel ("total", "engaged", "completed") of KPIs each counting a different slice.
+     * whole funnel ("total", "engaged", "completed") of KPIs each counting a different slice. An
+     * optional $window — a named {@see Period} or a [from, to] pair — scopes this widget to its own
+     * time window instead of the analytics-wide one (an all-time headline next to a recent trend).
      */
-    public function kpi(string $as, Metric $metric, string $field = '', Query|string|null $filter = null): static
+    public function kpi(string $as, Metric $metric, string $field = '', Query|string|null $filter = null, Period|array|null $window = null): static
     {
-        return $this->addFiltered(new Kpi($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $metric, $this->metricField($metric, $field)), $filter);
+        [$from, $to] = $this->resolveWindow($window);
+
+        return $this->addFiltered(new Kpi($as, $this->dateField, $from, $to, $this->dateFormat, $metric, $this->metricField($metric, $field)), $filter);
     }
 
-    public function kpiDelta(string $as, Metric $metric, string $field = '', Query|string|null $filter = null): static
+    public function kpiDelta(string $as, Metric $metric, string $field = '', Query|string|null $filter = null, Period|array|null $window = null): static
     {
-        [$previousFrom, $previousTo] = $this->previousWindow();
+        [$from, $to] = $this->resolveWindow($window);
+        [$previousFrom, $previousTo] = $this->previousWindow($from, $to, $window === null);
 
-        return $this->addFiltered(new KpiDelta($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $metric, $this->metricField($metric, $field), $previousFrom, $previousTo), $filter);
+        return $this->addFiltered(new KpiDelta($as, $this->dateField, $from, $to, $this->dateFormat, $metric, $this->metricField($metric, $field), $previousFrom, $previousTo), $filter);
     }
 
-    public function trend(string $as, Metric $metric, string $field = '', CalendarInterval|string $interval = CalendarInterval::Day, Query|string|null $filter = null): static
+    public function trend(string $as, Metric $metric, string $field = '', CalendarInterval|string $interval = CalendarInterval::Day, Query|string|null $filter = null, Period|array|null $window = null): static
     {
-        return $this->addFiltered(new Trend($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $metric, $this->metricField($metric, $field), $interval, $this->timeZone), $filter);
+        [$from, $to] = $this->resolveWindow($window);
+
+        return $this->addFiltered(new Trend($as, $this->dateField, $from, $to, $this->dateFormat, $metric, $this->metricField($metric, $field), $interval, $this->timeZone), $filter);
     }
 
-    public function cumulative(string $as, Metric $metric, string $field = '', CalendarInterval|string $interval = CalendarInterval::Day, Query|string|null $filter = null): static
+    public function cumulative(string $as, Metric $metric, string $field = '', CalendarInterval|string $interval = CalendarInterval::Day, Query|string|null $filter = null, Period|array|null $window = null): static
     {
-        return $this->addFiltered(new Cumulative($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $metric, $this->metricField($metric, $field), $interval, $this->timeZone), $filter);
+        [$from, $to] = $this->resolveWindow($window);
+
+        return $this->addFiltered(new Cumulative($as, $this->dateField, $from, $to, $this->dateFormat, $metric, $this->metricField($metric, $field), $interval, $this->timeZone), $filter);
     }
 
-    public function groupedTrend(string $as, Metric $metric, string $field, string $groupBy, CalendarInterval|string $interval = CalendarInterval::Day, int $limit = 5, Query|string|null $filter = null): static
+    public function groupedTrend(string $as, Metric $metric, string $field, string $groupBy, CalendarInterval|string $interval = CalendarInterval::Day, int $limit = 5, Query|string|null $filter = null, Period|array|null $window = null): static
     {
-        return $this->addFiltered(new GroupedTrend($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $metric, $this->metricField($metric, $field), $this->aggregatableField($groupBy), $interval, $limit, $this->timeZone), $filter);
+        [$from, $to] = $this->resolveWindow($window);
+
+        return $this->addFiltered(new GroupedTrend($as, $this->dateField, $from, $to, $this->dateFormat, $metric, $this->metricField($metric, $field), $this->aggregatableField($groupBy), $interval, $limit, $this->timeZone), $filter);
     }
 
-    public function breakdown(string $as, string $groupBy, Metric $metric, string $field = '', int $limit = 10, string $direction = 'desc', Query|string|null $filter = null): static
+    public function breakdown(string $as, string $groupBy, Metric $metric, string $field = '', int $limit = 10, string $direction = 'desc', Query|string|null $filter = null, Period|array|null $window = null): static
     {
-        return $this->addFiltered(new Breakdown($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $this->aggregatableField($groupBy), $metric, $this->metricField($metric, $field), $limit, $direction), $filter);
+        [$from, $to] = $this->resolveWindow($window);
+
+        return $this->addFiltered(new Breakdown($as, $this->dateField, $from, $to, $this->dateFormat, $this->aggregatableField($groupBy), $metric, $this->metricField($metric, $field), $limit, $direction), $filter);
     }
 
-    public function distribution(string $as, string $field, int $interval, Query|string|null $filter = null): static
+    public function distribution(string $as, string $field, int $interval, Query|string|null $filter = null, Period|array|null $window = null): static
     {
-        return $this->addFiltered(new Distribution($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $this->aggregatableField($field), $interval), $filter);
+        [$from, $to] = $this->resolveWindow($window);
+
+        return $this->addFiltered(new Distribution($as, $this->dateField, $from, $to, $this->dateFormat, $this->aggregatableField($field), $interval), $filter);
     }
 
     /**
      * @param  list<int|float>  $percents
      */
-    public function percentiles(string $as, string $field, array $percents = [50, 75, 95, 99], Query|string|null $filter = null): static
+    public function percentiles(string $as, string $field, array $percents = [50, 75, 95, 99], Query|string|null $filter = null, Period|array|null $window = null): static
     {
-        return $this->addFiltered(new Percentiles($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $this->aggregatableField($field), $percents), $filter);
+        [$from, $to] = $this->resolveWindow($window);
+
+        return $this->addFiltered(new Percentiles($as, $this->dateField, $from, $to, $this->dateFormat, $this->aggregatableField($field), $percents), $filter);
     }
 
     /**
@@ -237,17 +251,21 @@ class Analytics
      * limits the returned source (empty returns the full document); $sort is a "field:dir" string
      * ("amount:desc", defaults to descending) sorting the rows before $limit is applied.
      */
-    public function table(string $as, array $fields = [], int $limit = 10, ?string $sort = null, Query|string|null $filter = null): static
+    public function table(string $as, array $fields = [], int $limit = 10, ?string $sort = null, Query|string|null $filter = null, Period|array|null $window = null): static
     {
-        return $this->addFiltered(new Table($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $fields, $limit, $this->sortClause($sort)), $filter);
+        [$from, $to] = $this->resolveWindow($window);
+
+        return $this->addFiltered(new Table($as, $this->dateField, $from, $to, $this->dateFormat, $fields, $limit, $this->sortClause($sort)), $filter);
     }
 
     /**
      * Add the five-number summary (count, min, max, avg, sum) of a numeric field.
      */
-    public function stats(string $as, string $field, Query|string|null $filter = null): static
+    public function stats(string $as, string $field, Query|string|null $filter = null, Period|array|null $window = null): static
     {
-        return $this->addFiltered(new StatSummary($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $this->aggregatableField($field)), $filter);
+        [$from, $to] = $this->resolveWindow($window);
+
+        return $this->addFiltered(new StatSummary($as, $this->dateField, $from, $to, $this->dateFormat, $this->aggregatableField($field)), $filter);
     }
 
     /**
@@ -257,42 +275,50 @@ class Analytics
      *
      * @param  array<string, Query|string>  $steps
      */
-    public function funnel(string $as, array $steps, Query|string|null $filter = null): static
+    public function funnel(string $as, array $steps, Query|string|null $filter = null, Period|array|null $window = null): static
     {
+        [$from, $to] = $this->resolveWindow($window);
+
         $resolved = [];
 
         foreach ($steps as $label => $step) {
             $resolved[] = ['label' => (string) $label, 'query' => $this->resolveQuery($step)];
         }
 
-        return $this->addFiltered(new Funnel($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $resolved), $filter);
+        return $this->addFiltered(new Funnel($as, $this->dateField, $from, $to, $this->dateFormat, $resolved), $filter);
     }
 
     /**
      * Add a two-dimensional matrix — $rowField by $colField, each cell carrying $metric of $field.
      * Defaults to a count of documents per cell.
      */
-    public function heatmap(string $as, string $rowField, string $colField, Metric $metric = Metric::Count, string $field = '', int $rowLimit = 10, int $colLimit = 10, Query|string|null $filter = null): static
+    public function heatmap(string $as, string $rowField, string $colField, Metric $metric = Metric::Count, string $field = '', int $rowLimit = 10, int $colLimit = 10, Query|string|null $filter = null, Period|array|null $window = null): static
     {
-        return $this->addFiltered(new Heatmap($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $this->aggregatableField($rowField), $this->aggregatableField($colField), $metric, $this->metricField($metric, $field), $rowLimit, $colLimit), $filter);
+        [$from, $to] = $this->resolveWindow($window);
+
+        return $this->addFiltered(new Heatmap($as, $this->dateField, $from, $to, $this->dateFormat, $this->aggregatableField($rowField), $this->aggregatableField($colField), $metric, $this->metricField($metric, $field), $rowLimit, $colLimit), $filter);
     }
 
     /**
      * Add a cohort retention grid — entities (identified by $idField) grouped by the period of their
      * $cohortField date, counted distinct across each later $dateField period.
      */
-    public function retention(string $as, string $cohortField, string $idField, CalendarInterval|string $interval = CalendarInterval::Day, Query|string|null $filter = null): static
+    public function retention(string $as, string $cohortField, string $idField, CalendarInterval|string $interval = CalendarInterval::Day, Query|string|null $filter = null, Period|array|null $window = null): static
     {
-        return $this->addFiltered(new Retention($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $cohortField, $this->aggregatableField($idField), $interval, $this->timeZone), $filter);
+        [$from, $to] = $this->resolveWindow($window);
+
+        return $this->addFiltered(new Retention($as, $this->dateField, $from, $to, $this->dateFormat, $cohortField, $this->aggregatableField($idField), $interval, $this->timeZone), $filter);
     }
 
     /**
      * Add a map heatmap — $metric bucketed into geohash cells of a geo_point $field. Higher
      * $precision means smaller, more granular cells. Defaults to a count of documents per cell.
      */
-    public function geo(string $as, string $field, int $precision = 5, ?int $size = null, Metric $metric = Metric::Count, string $metricField = '', Query|string|null $filter = null): static
+    public function geo(string $as, string $field, int $precision = 5, ?int $size = null, Metric $metric = Metric::Count, string $metricField = '', Query|string|null $filter = null, Period|array|null $window = null): static
     {
-        return $this->addFiltered(new Geo($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $field, $precision, $size, $metric, $this->metricField($metric, $metricField)), $filter);
+        [$from, $to] = $this->resolveWindow($window);
+
+        return $this->addFiltered(new Geo($as, $this->dateField, $from, $to, $this->dateFormat, $field, $precision, $size, $metric, $this->metricField($metric, $metricField)), $filter);
     }
 
     /**
@@ -333,23 +359,6 @@ class Analytics
         }
 
         return $this->add($widget);
-    }
-
-    /**
-     * Override the time window of the most recently added widget. Mirrors the per-widget filter():
-     * chains right after a widget to scope just that one to its own window, so a single query can
-     * hold an all-time headline alongside a last-30-days trend.
-     *
-     *   ->kpi('total', Metric::Sum, 'amount')                          // analytics-wide window
-     *   ->trend('recent', Metric::Sum, 'amount')->over($from, $to);    // its own window
-     */
-    public function over(DateTimeInterface $from, DateTimeInterface $to): static
-    {
-        $widget = $this->widgets[$this->lastWidget] ?? throw new LogicException('over() must be called after adding a widget.');
-
-        $widget->window($from, $to);
-
-        return $this;
     }
 
     /**
@@ -431,30 +440,51 @@ class Analytics
     }
 
     /**
+     * Resolve an optional per-widget window override to a [from, to] pair, falling back to the
+     * analytics-wide window. A {@see Period} is resolved in the configured timezone (so the query stays
+     * cacheable); a [from, to] array of DateTimeInterface is taken as-is.
+     *
+     * @param  Period|array{0: DateTimeInterface, 1: DateTimeInterface}|null  $window
+     * @return array{0: DateTimeInterface, 1: DateTimeInterface}
+     */
+    protected function resolveWindow(Period|array|null $window): array
+    {
+        if ($window === null) {
+            return [$this->from, $this->to];
+        }
+
+        if ($window instanceof Period) {
+            return $window->resolve(new DateTimeImmutable('now', new DateTimeZone($this->timeZone ?? 'UTC')));
+        }
+
+        return $window;
+    }
+
+    /**
      * The window to compare a kpiDelta against: the previous instance of a named calendar period
-     * (this month → last month), or the immediately preceding equal-duration window otherwise.
+     * (this month → last month) when the widget uses the analytics-wide range, or the immediately
+     * preceding equal-duration window otherwise (including any per-widget window override).
      *
      * @return array{0: DateTimeInterface, 1: DateTimeInterface} [previousFrom, previousTo]
      */
-    protected function previousWindow(): array
+    protected function previousWindow(DateTimeInterface $from, DateTimeInterface $to, bool $usePeriod): array
     {
-        $previousTo = DateTimeImmutable::createFromInterface($this->from);
+        $previousTo = DateTimeImmutable::createFromInterface($from);
 
-        $modifier = $this->period?->previousModifier();
+        $modifier = $usePeriod ? $this->period?->previousModifier() : null;
 
         if ($modifier !== null) {
             return [$previousTo->modify($modifier), $previousTo];
         }
 
-        $length = $this->to->getTimestamp() - $this->from->getTimestamp();
+        $length = $to->getTimestamp() - $from->getTimestamp();
 
-        return [$previousTo->setTimestamp($this->from->getTimestamp() - $length), $previousTo];
+        return [$previousTo->setTimestamp($from->getTimestamp() - $length), $previousTo];
     }
 
     protected function add(Widget $widget): static
     {
         $this->widgets[$widget->name()] = $widget;
-        $this->lastWidget = $widget->name();
 
         return $this;
     }

--- a/src/Analytics/Analytics.php
+++ b/src/Analytics/Analytics.php
@@ -36,6 +36,7 @@ use Sigmie\Query\Contracts\QueryClause;
 use Sigmie\Query\NewQuery;
 use Sigmie\Query\Queries\Compound\Boolean;
 use Sigmie\Query\Queries\Query;
+use Sigmie\Query\Search;
 
 /**
  * Dashboard analytics for an index. Compose one or more widgets — KPIs, trends, breakdowns,
@@ -76,6 +77,8 @@ class Analytics
     protected ?Period $period = null;
 
     protected ?string $lastWidget = null;
+
+    protected ?Search $compiledSearch = null;
 
     protected ?Properties $resolvedProperties = null;
 
@@ -354,8 +357,45 @@ class Analytics
      */
     public function get(): array
     {
-        $aggregations = $this->run();
+        return $this->mapWidgets($this->run());
+    }
 
+    /**
+     * Turn a raw search response into the map of widget name => normalised result. Public so a
+     * multi-search caller that batched {@see toSearch()} into one _msearch can format that response
+     * slot directly, instead of going through {@see get()} (which runs its own request).
+     */
+    public function formatResponse(array $response): array
+    {
+        return $this->mapWidgets($response['aggregations'] ?? []);
+    }
+
+    /**
+     * The whole dashboard as a single MultiSearchable query — size(0), the analytics-wide filter, and
+     * every widget's aggregations. Add it to a newMultiSearch() to batch the dashboard into one
+     * _msearch round-trip alongside other searches (e.g. a paginated rows query that can't fold into
+     * aggregations), then feed the matching response slot back through {@see formatResponse()}.
+     *
+     *   $multi = $sigmie->newMultiSearch();
+     *   $multi->addQuery($analytics->toSearch(), 'metrics');
+     *   $multi->newSearch($index, 'rows')->queryString('…')->size(20);
+     *   [$metrics, $rows] = $multi->get();
+     *   $dashboard = $analytics->formatResponse($metrics);
+     */
+    public function toSearch(): NewQuery
+    {
+        $this->compile();
+
+        return $this->query;
+    }
+
+    protected function run(): array
+    {
+        return $this->compile()->response()->json('aggregations') ?? [];
+    }
+
+    protected function mapWidgets(array $aggregations): array
+    {
         $result = [];
 
         foreach ($this->widgets as $name => $widget) {
@@ -365,19 +405,20 @@ class Analytics
         return $result;
     }
 
-    protected function run(): array
+    /**
+     * Configure the underlying search once and memoise it, so the single-request {@see run()} and the
+     * multi-search {@see toSearch()} paths share one body and the widget aggregations are added once.
+     */
+    protected function compile(): Search
     {
-        $filters = $this->filters;
-        $filterQueries = $this->filterQueries;
-
-        $search = $this->query
+        return $this->compiledSearch ??= $this->query
             ->properties($this->properties)
-            ->bool(function (Boolean $boolean) use ($filters, $filterQueries): void {
+            ->bool(function (Boolean $boolean): void {
                 $filter = $boolean->filter();
 
-                $filters !== '' ? $filter->parse($filters) : $filter->matchAll();
+                $this->filters !== '' ? $filter->parse($this->filters) : $filter->matchAll();
 
-                foreach ($filterQueries as $query) {
+                foreach ($this->filterQueries as $query) {
                     $filter->query($query);
                 }
             })
@@ -387,8 +428,6 @@ class Analytics
                     $aggs->add($widget);
                 }
             });
-
-        return $search->response()->json('aggregations') ?? [];
     }
 
     /**

--- a/src/Analytics/Analytics.php
+++ b/src/Analytics/Analytics.php
@@ -8,15 +8,22 @@ use DateInterval;
 use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
+use LogicException;
 use Sigmie\Analytics\Enums\Metric;
 use Sigmie\Analytics\Enums\Period;
 use Sigmie\Analytics\Widgets\Breakdown;
 use Sigmie\Analytics\Widgets\Cumulative;
 use Sigmie\Analytics\Widgets\Distribution;
+use Sigmie\Analytics\Widgets\Funnel;
+use Sigmie\Analytics\Widgets\Geo;
 use Sigmie\Analytics\Widgets\GroupedTrend;
+use Sigmie\Analytics\Widgets\Heatmap;
 use Sigmie\Analytics\Widgets\Kpi;
 use Sigmie\Analytics\Widgets\KpiDelta;
 use Sigmie\Analytics\Widgets\Percentiles;
+use Sigmie\Analytics\Widgets\Retention;
+use Sigmie\Analytics\Widgets\StatSummary;
+use Sigmie\Analytics\Widgets\Table;
 use Sigmie\Analytics\Widgets\Trend;
 use Sigmie\Analytics\Widgets\Widget;
 use Sigmie\Mappings\NewProperties;
@@ -67,6 +74,8 @@ class Analytics
     protected ?string $timeZone = null;
 
     protected ?Period $period = null;
+
+    protected ?string $lastWidget = null;
 
     protected ?Properties $resolvedProperties = null;
 
@@ -221,6 +230,93 @@ class Analytics
     }
 
     /**
+     * Add a table of the actual matching documents — the rows behind a number, not a metric. $fields
+     * limits the returned source (empty returns the full document); $sort is a "field:dir" string
+     * ("amount:desc", defaults to descending) sorting the rows before $limit is applied.
+     */
+    public function table(string $as, array $fields = [], int $limit = 10, ?string $sort = null, Query|string|null $filter = null): static
+    {
+        return $this->addFiltered(new Table($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $fields, $limit, $this->sortClause($sort)), $filter);
+    }
+
+    /**
+     * Add the five-number summary (count, min, max, avg, sum) of a numeric field.
+     */
+    public function stats(string $as, string $field, Query|string|null $filter = null): static
+    {
+        return $this->addFiltered(new StatSummary($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $this->aggregatableField($field)), $filter);
+    }
+
+    /**
+     * Add an ordered step funnel. $steps is an ordered map of label => slice, where each slice is a
+     * filter-DSL string ("event:'signup'") or a query object; the result reports each step's count
+     * and its conversion against both the first and the previous step.
+     *
+     * @param  array<string, Query|string>  $steps
+     */
+    public function funnel(string $as, array $steps, Query|string|null $filter = null): static
+    {
+        $resolved = [];
+
+        foreach ($steps as $label => $step) {
+            $resolved[] = ['label' => (string) $label, 'query' => $this->resolveQuery($step)];
+        }
+
+        return $this->addFiltered(new Funnel($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $resolved), $filter);
+    }
+
+    /**
+     * Add a two-dimensional matrix — $rowField by $colField, each cell carrying $metric of $field.
+     * Defaults to a count of documents per cell.
+     */
+    public function heatmap(string $as, string $rowField, string $colField, Metric $metric = Metric::Count, string $field = '', int $rowLimit = 10, int $colLimit = 10, Query|string|null $filter = null): static
+    {
+        return $this->addFiltered(new Heatmap($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $this->aggregatableField($rowField), $this->aggregatableField($colField), $metric, $this->metricField($metric, $field), $rowLimit, $colLimit), $filter);
+    }
+
+    /**
+     * Add a cohort retention grid — entities (identified by $idField) grouped by the period of their
+     * $cohortField date, counted distinct across each later $dateField period.
+     */
+    public function retention(string $as, string $cohortField, string $idField, CalendarInterval|string $interval = CalendarInterval::Day, Query|string|null $filter = null): static
+    {
+        return $this->addFiltered(new Retention($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $cohortField, $this->aggregatableField($idField), $interval, $this->timeZone), $filter);
+    }
+
+    /**
+     * Add a map heatmap — $metric bucketed into geohash cells of a geo_point $field. Higher
+     * $precision means smaller, more granular cells. Defaults to a count of documents per cell.
+     */
+    public function geo(string $as, string $field, int $precision = 5, ?int $size = null, Metric $metric = Metric::Count, string $metricField = '', Query|string|null $filter = null): static
+    {
+        return $this->addFiltered(new Geo($as, $this->dateField, $this->from, $this->to, $this->dateFormat, $field, $precision, $size, $metric, $this->metricField($metric, $metricField)), $filter);
+    }
+
+    /**
+     * Turn a "field:dir" string into an Elasticsearch sort clause, resolving the field to its
+     * aggregatable path. The direction is optional and defaults to descending.
+     */
+    protected function sortClause(?string $sort): ?array
+    {
+        if ($sort === null) {
+            return null;
+        }
+
+        [$field, $direction] = array_pad(explode(':', $sort, 2), 2, 'desc');
+
+        return [[$this->aggregatableField($field) => ['order' => $direction]]];
+    }
+
+    /**
+     * Resolve a per-step slice to a query: a query object as-is, or a filter-DSL string parsed with
+     * the same {@see FilterParser} as the analytics-wide filters().
+     */
+    protected function resolveQuery(Query|string $query): Query
+    {
+        return $query instanceof Query ? $query : (new FilterParser($this->properties))->parse($query);
+    }
+
+    /**
      * Register a widget, first attaching an optional per-widget filter — a filter-DSL string
      * ("status:'paid'") or a query object — that scopes this widget to its own slice of the window.
      * A string is parsed with the same {@see FilterParser} as the analytics-wide filters().
@@ -234,6 +330,23 @@ class Analytics
         }
 
         return $this->add($widget);
+    }
+
+    /**
+     * Override the time window of the most recently added widget. Mirrors the per-widget filter():
+     * chains right after a widget to scope just that one to its own window, so a single query can
+     * hold an all-time headline alongside a last-30-days trend.
+     *
+     *   ->kpi('total', Metric::Sum, 'amount')                          // analytics-wide window
+     *   ->trend('recent', Metric::Sum, 'amount')->over($from, $to);    // its own window
+     */
+    public function over(DateTimeInterface $from, DateTimeInterface $to): static
+    {
+        $widget = $this->widgets[$this->lastWidget] ?? throw new LogicException('over() must be called after adding a widget.');
+
+        $widget->window($from, $to);
+
+        return $this;
     }
 
     /**
@@ -302,6 +415,7 @@ class Analytics
     protected function add(Widget $widget): static
     {
         $this->widgets[$widget->name()] = $widget;
+        $this->lastWidget = $widget->name();
 
         return $this;
     }

--- a/src/Analytics/Analytics.php
+++ b/src/Analytics/Analytics.php
@@ -36,6 +36,7 @@ use Sigmie\Query\NewQuery;
 use Sigmie\Query\Queries\Compound\Boolean;
 use Sigmie\Query\Queries\Query;
 use Sigmie\Query\Search;
+use Sigmie\Search\Contracts\MultiSearchable;
 
 /**
  * Dashboard analytics for an index. Compose one or more widgets — KPIs, trends, breakdowns,
@@ -50,8 +51,11 @@ use Sigmie\Query\Search;
  *       ->get();
  *
  * "Per day → per month" is the same call with a different {@see CalendarInterval}.
+ *
+ * Implements {@see MultiSearchable}, so a whole dashboard can be added to a {@see newMultiSearch()}
+ * (via newAnalytics()) and batched into one _msearch alongside other queries.
  */
-class Analytics
+class Analytics implements MultiSearchable
 {
     /**
      * @var array<string, Widget>
@@ -396,6 +400,25 @@ class Analytics
         $this->compile();
 
         return $this->query;
+    }
+
+    /**
+     * {@see MultiSearchable}: the _msearch header + body for this dashboard, so newMultiSearch() can
+     * batch it. The response slot comes back through {@see formatResponses()} as the widget map.
+     */
+    public function toMultiSearch(): array
+    {
+        return $this->toSearch()->toMultiSearch();
+    }
+
+    public function multisearchResCount(): int
+    {
+        return 1;
+    }
+
+    public function formatResponses(...$responses): array
+    {
+        return $this->formatResponse($responses[0] ?? []);
     }
 
     protected function run(): array

--- a/src/Analytics/Widgets/Funnel.php
+++ b/src/Analytics/Widgets/Funnel.php
@@ -35,7 +35,7 @@ class Funnel extends Widget
     {
         return $this->scoped($this->name, $this->from, $this->to, function (Aggs $aggs): void {
             foreach ($this->steps as $i => $step) {
-                $aggs->filter("step_{$i}", $step['query']);
+                $aggs->filter('step_'.$i, $step['query']);
             }
         })->toRaw();
     }
@@ -48,7 +48,7 @@ class Funnel extends Widget
         $previous = $first;
 
         $steps = (new Collection($this->steps))->map(function (array $step, int $i) use ($scope, $first, &$previous): array {
-            $count = $scope["step_{$i}"]['doc_count'] ?? 0;
+            $count = $scope['step_'.$i]['doc_count'] ?? 0;
 
             $row = [
                 'label' => $step['label'],

--- a/src/Analytics/Widgets/Funnel.php
+++ b/src/Analytics/Widgets/Funnel.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\Analytics\Widgets;
+
+use DateTimeInterface;
+use Sigmie\Query\Aggs;
+use Sigmie\Query\Queries\Query;
+use Sigmie\Shared\Collection;
+
+/**
+ * An ordered step funnel — how many documents match each stage and the conversion between them
+ * ("visited → signed up → paid"). Each step is its own `filter` bucket within the window, so the
+ * counts share one query. Conversion is reported both against the first step (overall) and against
+ * the previous step (stage-to-stage drop-off).
+ */
+class Funnel extends Widget
+{
+    /**
+     * @param  list<array{label: string, query: Query}>  $steps  Ordered funnel stages.
+     */
+    public function __construct(
+        string $name,
+        string $dateField,
+        DateTimeInterface $from,
+        DateTimeInterface $to,
+        string $dateFormat,
+        protected array $steps,
+    ) {
+        parent::__construct($name, $dateField, $from, $to, $dateFormat);
+    }
+
+    public function toRaw(): array
+    {
+        return $this->scoped($this->name, $this->from, $this->to, function (Aggs $aggs): void {
+            foreach ($this->steps as $i => $step) {
+                $aggs->filter("step_{$i}", $step['query']);
+            }
+        })->toRaw();
+    }
+
+    public function extract(array $aggregations): array
+    {
+        $scope = $aggregations[$this->name] ?? [];
+
+        $first = $scope['step_0']['doc_count'] ?? 0;
+        $previous = $first;
+
+        $steps = (new Collection($this->steps))->map(function (array $step, int $i) use ($scope, $first, &$previous): array {
+            $count = $scope["step_{$i}"]['doc_count'] ?? 0;
+
+            $row = [
+                'label' => $step['label'],
+                'count' => $count,
+                'conversion' => $first > 0 ? $count / $first : null,
+                'step_conversion' => $previous > 0 ? $count / $previous : null,
+            ];
+
+            $previous = $count;
+
+            return $row;
+        })->toArray();
+
+        return [
+            'type' => 'funnel',
+            'steps' => $steps,
+        ];
+    }
+}

--- a/src/Analytics/Widgets/Geo.php
+++ b/src/Analytics/Widgets/Geo.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\Analytics\Widgets;
+
+use DateTimeInterface;
+use Sigmie\Analytics\Enums\Metric;
+use Sigmie\Query\Aggs;
+use Sigmie\Shared\Collection;
+
+/**
+ * A map heatmap — a metric bucketed into geohash cells of a geo_point field ("orders by area",
+ * "errors by region"). Higher $precision means smaller, more granular cells. Backed by the
+ * `geohash_grid` aggregation with a metric sub-aggregation per cell.
+ */
+class Geo extends Widget
+{
+    public function __construct(
+        string $name,
+        string $dateField,
+        DateTimeInterface $from,
+        DateTimeInterface $to,
+        string $dateFormat,
+        protected string $field,
+        protected int $precision,
+        protected ?int $size,
+        protected Metric $metric,
+        protected string $metricField,
+    ) {
+        parent::__construct($name, $dateField, $from, $to, $dateFormat);
+    }
+
+    public function toRaw(): array
+    {
+        return $this->scoped($this->name, $this->from, $this->to, function (Aggs $aggs): void {
+            $aggs->geoHashGrid('grid', $this->field, $this->precision, $this->size)
+                ->aggregate(fn (Aggs $m) => $this->metric->apply($m, 'metric', $this->metricField));
+        })->toRaw();
+    }
+
+    public function extract(array $aggregations): array
+    {
+        $buckets = new Collection($aggregations[$this->name]['grid']['buckets'] ?? []);
+
+        return [
+            'type' => 'geo',
+            'metric' => $this->metric->value,
+            'field' => $this->field,
+            'precision' => $this->precision,
+            'buckets' => $buckets->map(fn (array $bucket): array => [
+                'geohash' => $bucket['key'],
+                'value' => $this->metric->extract($bucket['metric'] ?? []),
+                'count' => $bucket['doc_count'] ?? 0,
+            ])->toArray(),
+        ];
+    }
+}

--- a/src/Analytics/Widgets/Heatmap.php
+++ b/src/Analytics/Widgets/Heatmap.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\Analytics\Widgets;
+
+use DateTimeInterface;
+use Sigmie\Analytics\Enums\Metric;
+use Sigmie\Query\Aggs;
+use Sigmie\Shared\Collection;
+
+/**
+ * A two-dimensional matrix — one dimension by another, each cell carrying a metric
+ * ("country × device by revenue", "status × priority by count"). Backed by nested `terms`
+ * buckets with a metric sub-aggregation on each cell.
+ */
+class Heatmap extends Widget
+{
+    public function __construct(
+        string $name,
+        string $dateField,
+        DateTimeInterface $from,
+        DateTimeInterface $to,
+        string $dateFormat,
+        protected string $rowField,
+        protected string $colField,
+        protected Metric $metric,
+        protected string $field,
+        protected int $rowLimit,
+        protected int $colLimit,
+    ) {
+        parent::__construct($name, $dateField, $from, $to, $dateFormat);
+    }
+
+    public function toRaw(): array
+    {
+        return $this->scoped($this->name, $this->from, $this->to, function (Aggs $aggs): void {
+            $aggs->terms('rows', $this->rowField)
+                ->size($this->rowLimit)
+                ->aggregate(function (Aggs $sub): void {
+                    $sub->terms('cols', $this->colField)
+                        ->size($this->colLimit)
+                        ->aggregate(fn (Aggs $m) => $this->metric->apply($m, 'metric', $this->field));
+                });
+        })->toRaw();
+    }
+
+    public function extract(array $aggregations): array
+    {
+        $rows = new Collection($aggregations[$this->name]['rows']['buckets'] ?? []);
+
+        return [
+            'type' => 'heatmap',
+            'metric' => $this->metric->value,
+            'field' => $this->field,
+            'row_field' => $this->rowField,
+            'col_field' => $this->colField,
+            'rows' => $rows->map(fn (array $row): array => [
+                'key' => $row['key'],
+                'count' => $row['doc_count'] ?? 0,
+                'cells' => array_map(fn (array $cell): array => [
+                    'key' => $cell['key'],
+                    'value' => $this->metric->extract($cell['metric'] ?? []),
+                    'count' => $cell['doc_count'] ?? 0,
+                ], $row['cols']['buckets'] ?? []),
+            ])->toArray(),
+        ];
+    }
+}

--- a/src/Analytics/Widgets/Retention.php
+++ b/src/Analytics/Widgets/Retention.php
@@ -6,6 +6,7 @@ namespace Sigmie\Analytics\Widgets;
 
 use DateTimeInterface;
 use Sigmie\Query\Aggregations\Enums\CalendarInterval;
+use Sigmie\Query\Aggregations\Metrics\Cardinality;
 use Sigmie\Query\Aggs;
 use Sigmie\Shared\Collection;
 
@@ -40,7 +41,7 @@ class Retention extends Widget
                 ->aggregate(function (Aggs $sub): void {
                     $sub->cardinality('size', $this->idField);
                     $sub->dateHistogram('periods', $this->dateField, $this->interval, extendedBounds: $this->extendedBounds(), timeZone: $this->timeZone)
-                        ->aggregate(fn (Aggs $m) => $m->cardinality('users', $this->idField));
+                        ->aggregate(fn (Aggs $m): Cardinality => $m->cardinality('users', $this->idField));
                 });
         })->toRaw();
     }

--- a/src/Analytics/Widgets/Retention.php
+++ b/src/Analytics/Widgets/Retention.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\Analytics\Widgets;
+
+use DateTimeInterface;
+use Sigmie\Query\Aggregations\Enums\CalendarInterval;
+use Sigmie\Query\Aggs;
+use Sigmie\Shared\Collection;
+
+/**
+ * A cohort retention grid — entities grouped by the period of their cohort date (e.g. sign-up),
+ * then counted, distinct, across each later activity period. Reads as the classic triangular
+ * retention table: one row per cohort, one cell per period.
+ *
+ * Backed by a `date_histogram` on the cohort field, a nested `date_histogram` on the activity
+ * field, and a `cardinality` of the entity id so each cell counts distinct entities, not events.
+ */
+class Retention extends Widget
+{
+    public function __construct(
+        string $name,
+        string $dateField,
+        DateTimeInterface $from,
+        DateTimeInterface $to,
+        string $dateFormat,
+        protected string $cohortField,
+        protected string $idField,
+        protected CalendarInterval|string $interval,
+        protected ?string $timeZone = null,
+    ) {
+        parent::__construct($name, $dateField, $from, $to, $dateFormat);
+    }
+
+    public function toRaw(): array
+    {
+        return $this->scoped($this->name, $this->from, $this->to, function (Aggs $aggs): void {
+            $aggs->dateHistogram('cohorts', $this->cohortField, $this->interval, timeZone: $this->timeZone)
+                ->aggregate(function (Aggs $sub): void {
+                    $sub->cardinality('size', $this->idField);
+                    $sub->dateHistogram('periods', $this->dateField, $this->interval, extendedBounds: $this->extendedBounds(), timeZone: $this->timeZone)
+                        ->aggregate(fn (Aggs $m) => $m->cardinality('users', $this->idField));
+                });
+        })->toRaw();
+    }
+
+    public function extract(array $aggregations): array
+    {
+        $cohorts = new Collection($aggregations[$this->name]['cohorts']['buckets'] ?? []);
+
+        return [
+            'type' => 'retention',
+            'cohort_field' => $this->cohortField,
+            'interval' => $this->interval instanceof CalendarInterval ? $this->interval->name : $this->interval,
+            'cohorts' => $cohorts->map(fn (array $cohort): array => [
+                'cohort' => $cohort['key_as_string'],
+                'size' => $cohort['size']['value'] ?? 0,
+                'periods' => array_map(fn (array $bucket): array => [
+                    'label' => $bucket['key_as_string'],
+                    'value' => $bucket['users']['value'] ?? 0,
+                ], $cohort['periods']['buckets'] ?? []),
+            ])->toArray(),
+        ];
+    }
+}

--- a/src/Analytics/Widgets/StatSummary.php
+++ b/src/Analytics/Widgets/StatSummary.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\Analytics\Widgets;
+
+use DateTimeInterface;
+use Sigmie\Query\Aggs;
+
+/**
+ * The five-number summary of a numeric field in one tile — count, min, max, avg and sum
+ * ("order-size summary", "response-time summary"). Backed by the `stats` aggregation.
+ */
+class StatSummary extends Widget
+{
+    public function __construct(
+        string $name,
+        string $dateField,
+        DateTimeInterface $from,
+        DateTimeInterface $to,
+        string $dateFormat,
+        protected string $field,
+    ) {
+        parent::__construct($name, $dateField, $from, $to, $dateFormat);
+    }
+
+    public function toRaw(): array
+    {
+        return $this->scoped($this->name, $this->from, $this->to, function (Aggs $aggs): void {
+            $aggs->stats('stats', $this->field);
+        })->toRaw();
+    }
+
+    public function extract(array $aggregations): array
+    {
+        $stats = $aggregations[$this->name]['stats'] ?? [];
+
+        return [
+            'type' => 'stats',
+            'field' => $this->field,
+            'count' => $stats['count'] ?? 0,
+            'min' => $stats['min'] ?? null,
+            'max' => $stats['max'] ?? null,
+            'avg' => $stats['avg'] ?? null,
+            'sum' => $stats['sum'] ?? null,
+        ];
+    }
+}

--- a/src/Analytics/Widgets/Table.php
+++ b/src/Analytics/Widgets/Table.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\Analytics\Widgets;
+
+use DateTimeInterface;
+use Sigmie\Query\Aggs;
+use Sigmie\Shared\Collection;
+
+/**
+ * The actual matching documents for the window/slice — the rows behind a number, not a metric
+ * ("the 20 most recent orders", "the latest errors in this slice"). Backed by a `top_hits`
+ * aggregation, so it composes with the same per-widget filter() and window as every other widget.
+ */
+class Table extends Widget
+{
+    /**
+     * @param  list<string>  $fields  Source fields to return per row; empty returns the full document.
+     * @param  array<int, array<string, mixed>>|null  $sort  Elasticsearch sort clauses.
+     */
+    public function __construct(
+        string $name,
+        string $dateField,
+        DateTimeInterface $from,
+        DateTimeInterface $to,
+        string $dateFormat,
+        protected array $fields,
+        protected int $limit,
+        protected ?array $sort,
+    ) {
+        parent::__construct($name, $dateField, $from, $to, $dateFormat);
+    }
+
+    public function toRaw(): array
+    {
+        return $this->scoped($this->name, $this->from, $this->to, function (Aggs $aggs): void {
+            $aggs->topHits('hits', size: $this->limit, sourceIncludes: $this->fields === [] ? null : $this->fields, sort: $this->sort);
+        })->toRaw();
+    }
+
+    public function extract(array $aggregations): array
+    {
+        $hits = new Collection($aggregations[$this->name]['hits']['hits']['hits'] ?? []);
+
+        return [
+            'type' => 'table',
+            'rows' => $hits->map(fn (array $hit): array => [
+                'id' => $hit['_id'] ?? null,
+                'document' => $hit['_source'] ?? [],
+            ])->toArray(),
+        ];
+    }
+}

--- a/src/Analytics/Widgets/Widget.php
+++ b/src/Analytics/Widgets/Widget.php
@@ -40,20 +40,6 @@ abstract class Widget implements ToRaw
     }
 
     /**
-     * Override this widget's own time window, independent of the analytics-wide from()/to(). Lets one
-     * query mix windows — an all-time headline KPI next to a last-30-days trend — without a second
-     * request. Like filter(), it scopes this widget only; every widget renders through scoped(), which
-     * reads these bounds, so the override propagates to the filter bucket and the extended bounds alike.
-     */
-    public function window(DateTimeInterface $from, DateTimeInterface $to): static
-    {
-        $this->from = $from;
-        $this->to = $to;
-
-        return $this;
-    }
-
-    /**
      * Restrict this widget to a slice of the window. Unlike the analytics-wide filters()/filterQuery(),
      * this applies to this widget only, so a single query can hold widgets counting different slices —
      * e.g. a funnel of "total", "engaged" and "completed" KPIs over the same time window.

--- a/src/Analytics/Widgets/Widget.php
+++ b/src/Analytics/Widgets/Widget.php
@@ -40,6 +40,20 @@ abstract class Widget implements ToRaw
     }
 
     /**
+     * Override this widget's own time window, independent of the analytics-wide from()/to(). Lets one
+     * query mix windows — an all-time headline KPI next to a last-30-days trend — without a second
+     * request. Like filter(), it scopes this widget only; every widget renders through scoped(), which
+     * reads these bounds, so the override propagates to the filter bucket and the extended bounds alike.
+     */
+    public function window(DateTimeInterface $from, DateTimeInterface $to): static
+    {
+        $this->from = $from;
+        $this->to = $to;
+
+        return $this;
+    }
+
+    /**
      * Restrict this widget to a slice of the window. Unlike the analytics-wide filters()/filterQuery(),
      * this applies to this widget only, so a single query can hold widgets counting different slices —
      * e.g. a funnel of "total", "engaged" and "completed" KPIs over the same time window.

--- a/src/Query/Aggregations/Bucket/GeoHashGrid.php
+++ b/src/Query/Aggregations/Bucket/GeoHashGrid.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\Query\Aggregations\Bucket;
+
+class GeoHashGrid extends Bucket
+{
+    public function __construct(
+        protected string $name,
+        protected string $field,
+        protected int $precision = 5,
+        protected ?int $size = null,
+    ) {
+        parent::__construct($name);
+    }
+
+    protected function value(): array
+    {
+        $grid = [
+            'field' => $this->field,
+            'precision' => $this->precision,
+        ];
+
+        if ($this->size !== null) {
+            $grid['size'] = $this->size;
+        }
+
+        return [
+            'geohash_grid' => $grid,
+        ];
+    }
+}

--- a/src/Query/Aggs.php
+++ b/src/Query/Aggs.php
@@ -8,6 +8,7 @@ use Sigmie\Query\Aggregations\Bucket\AutoDateHistogram;
 use Sigmie\Query\Aggregations\Bucket\BucketSelector;
 use Sigmie\Query\Aggregations\Bucket\DateHistogram;
 use Sigmie\Query\Aggregations\Bucket\Filter;
+use Sigmie\Query\Aggregations\Bucket\GeoHashGrid;
 use Sigmie\Query\Aggregations\Bucket\Global_;
 use Sigmie\Query\Aggregations\Bucket\Histogram;
 use Sigmie\Query\Aggregations\Bucket\Missing;
@@ -159,6 +160,19 @@ class Aggs implements AggsInterface
         ?string $timeZone = null,
     ): DateHistogram {
         $aggregation = new DateHistogram($name, $field, $interval, $minDocCount, $extendedBounds, $format, $timeZone);
+
+        $this->aggs[] = $aggregation;
+
+        return $aggregation;
+    }
+
+    public function geoHashGrid(
+        string $name,
+        string $field,
+        int $precision = 5,
+        ?int $size = null,
+    ): GeoHashGrid {
+        $aggregation = new GeoHashGrid($name, $field, $precision, $size);
 
         $this->aggs[] = $aggregation;
 

--- a/src/Search/NewMultiSearch.php
+++ b/src/Search/NewMultiSearch.php
@@ -12,10 +12,10 @@ use Sigmie\Base\Contracts\ElasticsearchConnection;
 use Sigmie\Base\ElasticsearchException;
 use Sigmie\Document\Hit;
 use Sigmie\Query\NewQuery;
-use Sigmie\SigmieIndex;
 use Sigmie\Search\Contracts\LazyIterableQuery;
 use Sigmie\Search\Contracts\MultiSearchable;
 use Sigmie\Shared\UsesApis;
+use Sigmie\SigmieIndex;
 
 use function Sigmie\Functions\random_name;
 

--- a/src/Search/NewMultiSearch.php
+++ b/src/Search/NewMultiSearch.php
@@ -6,11 +6,13 @@ namespace Sigmie\Search;
 
 use Closure;
 use Generator;
+use Sigmie\Analytics\Analytics;
 use Sigmie\Base\APIs\MSearch;
 use Sigmie\Base\Contracts\ElasticsearchConnection;
 use Sigmie\Base\ElasticsearchException;
 use Sigmie\Document\Hit;
 use Sigmie\Query\NewQuery;
+use Sigmie\SigmieIndex;
 use Sigmie\Search\Contracts\LazyIterableQuery;
 use Sigmie\Search\Contracts\MultiSearchable;
 use Sigmie\Shared\UsesApis;
@@ -72,6 +74,21 @@ class NewMultiSearch
         $this->names[count($this->queries) - 1] = $name ?? random_name('srch');
 
         return $query;
+    }
+
+    /**
+     * Start a dashboard-analytics query in the batch. Compose widgets on the returned Analytics; at
+     * get() time the whole dashboard is serialised into the same _msearch, and its response slot comes
+     * back already mapped to the widget result map.
+     */
+    public function newAnalytics(SigmieIndex $index, string $dateField, ?string $name = null): Analytics
+    {
+        $analytics = $index->analytics($dateField);
+
+        $this->queries[] = $analytics;
+        $this->names[count($this->queries) - 1] = $name ?? random_name('srch');
+
+        return $analytics;
     }
 
     public function raw(string $index, array $query, ?string $name = null): RawQuery

--- a/src/Search/NewMultiSearch.php
+++ b/src/Search/NewMultiSearch.php
@@ -66,6 +66,14 @@ class NewMultiSearch
         return $query;
     }
 
+    public function addQuery(NewQuery $query, ?string $name = null): NewQuery
+    {
+        $this->queries[] = $query;
+        $this->names[count($this->queries) - 1] = $name ?? random_name('srch');
+
+        return $query;
+    }
+
     public function raw(string $index, array $query, ?string $name = null): RawQuery
     {
         $raw = new RawQuery($this->elasticsearchConnection, $index, $query);

--- a/tests/AnalyticsTest.php
+++ b/tests/AnalyticsTest.php
@@ -877,7 +877,7 @@ class AnalyticsTest extends TestCase
             ->from($this->date('2024-01-01'))
             ->to($this->date('2024-01-04'))
             ->kpi('all_time', Metric::Sum, 'amount')
-            ->kpi('first_day', Metric::Sum, 'amount')->over($this->date('2024-01-01'), $this->date('2024-01-02'))
+            ->kpi('first_day', Metric::Sum, 'amount', window: [$this->date('2024-01-01'), $this->date('2024-01-02')])
             ->get();
 
         $this->assertEquals(450.0, $result['all_time']['value']);

--- a/tests/AnalyticsTest.php
+++ b/tests/AnalyticsTest.php
@@ -633,4 +633,253 @@ class AnalyticsTest extends TestCase
         $this->assertEquals(0.0, $groups['A'][4]['value']);
         $this->assertEquals(0.0, $groups['B'][4]['value']);
     }
+
+    /**
+     * Build a throwaway index from a properties definition and a set of documents.
+     *
+     * @param  callable(NewProperties): void  $defineProperties
+     * @param  list<Document>  $documents
+     */
+    private function indexWith(callable $defineProperties, array $documents): SigmieIndex
+    {
+        $index = new class($this->sigmie, $defineProperties) extends SigmieIndex
+        {
+            protected string $indexName;
+
+            /** @var callable(NewProperties): void */
+            protected $define;
+
+            public function __construct(Sigmie $sigmie, callable $define)
+            {
+                parent::__construct($sigmie);
+
+                $this->indexName = uniqid();
+                $this->define = $define;
+            }
+
+            public function name(): string
+            {
+                return $this->indexName;
+            }
+
+            public function properties(): NewProperties
+            {
+                $props = new NewProperties;
+
+                ($this->define)($props);
+
+                return $props;
+            }
+        };
+
+        $index->create();
+        $index->merge($documents, refresh: true);
+
+        return $index;
+    }
+
+    /**
+     * @test
+     */
+    public function table_returns_the_matching_documents(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $result = $index->analytics('created_at')
+            ->from($this->date('2024-01-01'))
+            ->to($this->date('2024-01-04'))
+            ->table('recent', fields: ['amount', 'product'], limit: 2, sort: 'amount:desc')
+            ->get();
+
+        $rows = $result['recent']['rows'];
+
+        $this->assertSame('table', $result['recent']['type']);
+        $this->assertCount(2, $rows);
+        $this->assertEquals(200, $rows[0]['document']['amount']);
+        $this->assertSame('A', $rows[0]['document']['product']);
+        $this->assertEquals(100, $rows[1]['document']['amount']);
+        $this->assertNotNull($rows[0]['id']);
+    }
+
+    /**
+     * @test
+     */
+    public function stats_summarises_a_numeric_field(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $result = $index->analytics('created_at')
+            ->from($this->date('2024-01-01'))
+            ->to($this->date('2024-01-04'))
+            ->stats('order_size', 'amount')
+            ->get();
+
+        $stats = $result['order_size'];
+
+        $this->assertSame('stats', $stats['type']);
+        $this->assertEquals(5, $stats['count']);
+        $this->assertEquals(30.0, $stats['min']);
+        $this->assertEquals(200.0, $stats['max']);
+        $this->assertEquals(450.0, $stats['sum']);
+        $this->assertEquals(90.0, $stats['avg']);
+    }
+
+    /**
+     * @test
+     */
+    public function funnel_reports_step_conversions(): void
+    {
+        $index = $this->indexWith(function (NewProperties $props): void {
+            $props->date('created_at');
+            $props->category('event');
+        }, [
+            new Document(['created_at' => '2024-01-01', 'event' => 'visit']),
+            new Document(['created_at' => '2024-01-01', 'event' => 'visit']),
+            new Document(['created_at' => '2024-01-02', 'event' => 'visit']),
+            new Document(['created_at' => '2024-01-02', 'event' => 'visit']),
+            new Document(['created_at' => '2024-01-02', 'event' => 'signup']),
+            new Document(['created_at' => '2024-01-03', 'event' => 'signup']),
+            new Document(['created_at' => '2024-01-03', 'event' => 'paid']),
+        ]);
+
+        $result = $index->analytics('created_at')
+            ->from($this->date('2024-01-01'))
+            ->to($this->date('2024-01-04'))
+            ->funnel('signup', [
+                'visited' => "event:'visit'",
+                'signed' => "event:'signup'",
+                'paid' => "event:'paid'",
+            ])
+            ->get();
+
+        $steps = $result['signup']['steps'];
+
+        $this->assertSame('funnel', $result['signup']['type']);
+        $this->assertSame(['visited', 'signed', 'paid'], array_column($steps, 'label'));
+        $this->assertEquals([4, 2, 1], array_column($steps, 'count'));
+        $this->assertEquals(1.0, $steps[0]['conversion']);
+        $this->assertEquals(0.5, $steps[1]['conversion']);
+        $this->assertEquals(0.25, $steps[2]['conversion']);
+        $this->assertEquals(0.5, $steps[2]['step_conversion']);
+    }
+
+    /**
+     * @test
+     */
+    public function heatmap_crosses_two_dimensions(): void
+    {
+        $index = $this->indexWith(function (NewProperties $props): void {
+            $props->date('created_at');
+            $props->category('region');
+            $props->category('device');
+        }, [
+            new Document(['created_at' => '2024-01-01', 'region' => 'US', 'device' => 'mobile']),
+            new Document(['created_at' => '2024-01-01', 'region' => 'US', 'device' => 'mobile']),
+            new Document(['created_at' => '2024-01-02', 'region' => 'US', 'device' => 'desktop']),
+            new Document(['created_at' => '2024-01-02', 'region' => 'EU', 'device' => 'mobile']),
+        ]);
+
+        $result = $index->analytics('created_at')
+            ->from($this->date('2024-01-01'))
+            ->to($this->date('2024-01-04'))
+            ->heatmap('regions', 'region', 'device')
+            ->get();
+
+        $cells = [];
+        foreach ($result['regions']['rows'] as $row) {
+            foreach ($row['cells'] as $cell) {
+                $cells["{$row['key']}/{$cell['key']}"] = $cell['count'];
+            }
+        }
+
+        $this->assertSame('heatmap', $result['regions']['type']);
+        $this->assertEquals(2, $cells['US/mobile']);
+        $this->assertEquals(1, $cells['US/desktop']);
+        $this->assertEquals(1, $cells['EU/mobile']);
+    }
+
+    /**
+     * @test
+     */
+    public function retention_grids_cohorts_by_period(): void
+    {
+        $index = $this->indexWith(function (NewProperties $props): void {
+            $props->date('created_at');
+            $props->date('signup_at');
+            $props->category('user');
+        }, [
+            new Document(['created_at' => '2024-01-01', 'signup_at' => '2024-01-01', 'user' => 'u1']),
+            new Document(['created_at' => '2024-01-02', 'signup_at' => '2024-01-01', 'user' => 'u1']),
+            new Document(['created_at' => '2024-01-01', 'signup_at' => '2024-01-01', 'user' => 'u2']),
+            new Document(['created_at' => '2024-01-02', 'signup_at' => '2024-01-02', 'user' => 'u3']),
+        ]);
+
+        $result = $index->analytics('created_at')
+            ->from($this->date('2024-01-01'))
+            ->to($this->date('2024-01-03'))
+            ->retention('cohorts', 'signup_at', 'user', CalendarInterval::Day)
+            ->get();
+
+        $cohorts = [];
+        foreach ($result['cohorts']['cohorts'] as $cohort) {
+            $periods = [];
+            foreach ($cohort['periods'] as $period) {
+                $periods[substr($period['label'], 0, 10)] = $period['value'];
+            }
+            $cohorts[substr($cohort['cohort'], 0, 10)] = ['size' => $cohort['size'], 'periods' => $periods];
+        }
+
+        $this->assertSame('retention', $result['cohorts']['type']);
+        $this->assertEquals(2, $cohorts['2024-01-01']['size']);
+        $this->assertEquals(2, $cohorts['2024-01-01']['periods']['2024-01-01']);
+        $this->assertEquals(1, $cohorts['2024-01-01']['periods']['2024-01-02']);
+        $this->assertEquals(1, $cohorts['2024-01-02']['size']);
+        $this->assertEquals(1, $cohorts['2024-01-02']['periods']['2024-01-02']);
+    }
+
+    /**
+     * @test
+     */
+    public function geo_buckets_points_into_cells(): void
+    {
+        $index = $this->indexWith(function (NewProperties $props): void {
+            $props->date('created_at');
+            $props->geoPoint('location');
+        }, [
+            new Document(['created_at' => '2024-01-01', 'location' => ['lat' => 52.37, 'lon' => 4.90]]),
+            new Document(['created_at' => '2024-01-01', 'location' => ['lat' => 52.37, 'lon' => 4.90]]),
+            new Document(['created_at' => '2024-01-02', 'location' => ['lat' => 40.71, 'lon' => -74.00]]),
+        ]);
+
+        $result = $index->analytics('created_at')
+            ->from($this->date('2024-01-01'))
+            ->to($this->date('2024-01-04'))
+            ->geo('areas', 'location', precision: 5)
+            ->get();
+
+        $buckets = $result['areas']['buckets'];
+
+        $this->assertSame('geo', $result['areas']['type']);
+        $this->assertCount(2, $buckets);
+        $this->assertEquals(2, $buckets[0]['count']);
+        $this->assertEquals(1, $buckets[1]['count']);
+    }
+
+    /**
+     * @test
+     */
+    public function a_widget_can_override_its_window(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $result = $index->analytics('created_at')
+            ->from($this->date('2024-01-01'))
+            ->to($this->date('2024-01-04'))
+            ->kpi('all_time', Metric::Sum, 'amount')
+            ->kpi('first_day', Metric::Sum, 'amount')->over($this->date('2024-01-01'), $this->date('2024-01-02'))
+            ->get();
+
+        $this->assertEquals(450.0, $result['all_time']['value']);
+        $this->assertEquals(150.0, $result['first_day']['value']);
+    }
 }

--- a/tests/AnalyticsTest.php
+++ b/tests/AnalyticsTest.php
@@ -910,4 +910,28 @@ class AnalyticsTest extends TestCase
         $this->assertSame('A', $dashboard['top_products']['rows'][0]['key']);
         $this->assertCount(2, $rows['hits']['hits']);
     }
+
+    /**
+     * @test
+     */
+    public function multi_search_can_build_analytics_inline(): void
+    {
+        $index = $this->createSalesIndex();
+        $name = $index->name();
+
+        $multi = $this->sigmie->newMultiSearch();
+        $multi->newAnalytics($index, 'created_at', 'metrics')
+            ->from($this->date('2024-01-01'))
+            ->to($this->date('2024-01-04'))
+            ->kpi('revenue', Metric::Sum, 'amount')
+            ->breakdown('top_products', 'product', Metric::Sum, 'amount');
+        $multi->newQuery($name, 'rows')->matchAll()->size(2);
+
+        [$metrics, $rows] = $multi->get();
+
+        // newAnalytics formats its own slot — the result is already the widget map.
+        $this->assertEquals(450.0, $metrics['revenue']['value']);
+        $this->assertSame('A', $metrics['top_products']['rows'][0]['key']);
+        $this->assertCount(2, $rows['hits']['hits']);
+    }
 }

--- a/tests/AnalyticsTest.php
+++ b/tests/AnalyticsTest.php
@@ -788,7 +788,7 @@ class AnalyticsTest extends TestCase
         $cells = [];
         foreach ($result['regions']['rows'] as $row) {
             foreach ($row['cells'] as $cell) {
-                $cells["{$row['key']}/{$cell['key']}"] = $cell['count'];
+                $cells[sprintf('%s/%s', $row['key'], $cell['key'])] = $cell['count'];
             }
         }
 
@@ -826,6 +826,7 @@ class AnalyticsTest extends TestCase
             foreach ($cohort['periods'] as $period) {
                 $periods[substr($period['label'], 0, 10)] = $period['value'];
             }
+
             $cohorts[substr($cohort['cohort'], 0, 10)] = ['size' => $cohort['size'], 'periods' => $periods];
         }
 

--- a/tests/AnalyticsTest.php
+++ b/tests/AnalyticsTest.php
@@ -883,4 +883,31 @@ class AnalyticsTest extends TestCase
         $this->assertEquals(450.0, $result['all_time']['value']);
         $this->assertEquals(150.0, $result['first_day']['value']);
     }
+
+    /**
+     * @test
+     */
+    public function analytics_can_ride_in_a_multi_search(): void
+    {
+        $index = $this->createSalesIndex();
+        $name = $index->name();
+
+        $analytics = $index->analytics('created_at')
+            ->from($this->date('2024-01-01'))
+            ->to($this->date('2024-01-04'))
+            ->kpi('revenue', Metric::Sum, 'amount')
+            ->breakdown('top_products', 'product', Metric::Sum, 'amount');
+
+        $multi = $this->sigmie->newMultiSearch();
+        $multi->addQuery($analytics->toSearch(), 'metrics');
+        $multi->newQuery($name, 'rows')->matchAll()->size(2);
+
+        [$metrics, $rows] = $multi->get();
+
+        $dashboard = $analytics->formatResponse($metrics);
+
+        $this->assertEquals(450.0, $dashboard['revenue']['value']);
+        $this->assertSame('A', $dashboard['top_products']['rows'][0]['key']);
+        $this->assertCount(2, $rows['hits']['hits']);
+    }
 }

--- a/tests/SigmieAnalyticsToolTest.php
+++ b/tests/SigmieAnalyticsToolTest.php
@@ -140,7 +140,7 @@ class SigmieAnalyticsToolTest extends TestCase
         $this->assertStringContainsString('Examples (', $description);
 
         // One example per widget, as valid JSON grounded in the index's real fields.
-        foreach (['kpi', 'kpi_delta', 'trend', 'cumulative', 'grouped_trend', 'breakdown', 'distribution', 'percentiles'] as $widget) {
+        foreach (['kpi', 'kpi_delta', 'trend', 'cumulative', 'grouped_trend', 'breakdown', 'distribution', 'percentiles', 'stats', 'table', 'funnel', 'heatmap', 'retention', 'geo'] as $widget) {
             $this->assertStringContainsString(sprintf('"widget":"%s"', $widget), $description);
         }
 
@@ -214,6 +214,70 @@ class SigmieAnalyticsToolTest extends TestCase
 
         $this->assertSame('A', $result['rows'][0]['key']);
         $this->assertEquals(370.0, $result['rows'][0]['value']);
+    }
+
+    /**
+     * @test
+     */
+    public function result_runs_a_stats_widget(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $result = (new SigmieAnalyticsTool($index))->result(new Request([
+            'widget' => 'stats',
+            'date_field' => 'created_at',
+            'field' => 'amount',
+            'from' => '2024-01-01',
+            'to' => '2024-01-04',
+        ]));
+
+        $this->assertSame('stats', $result['type']);
+        $this->assertEquals(5, $result['count']);
+        $this->assertEquals(450.0, $result['sum']);
+        $this->assertEquals(200.0, $result['max']);
+    }
+
+    /**
+     * @test
+     */
+    public function result_runs_a_table_widget(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $result = (new SigmieAnalyticsTool($index))->result(new Request([
+            'widget' => 'table',
+            'date_field' => 'created_at',
+            'fields' => 'amount,product',
+            'sort' => 'amount:desc',
+            'limit' => 2,
+            'from' => '2024-01-01',
+            'to' => '2024-01-04',
+        ]));
+
+        $this->assertSame('table', $result['type']);
+        $this->assertCount(2, $result['rows']);
+        $this->assertEquals(200, $result['rows'][0]['document']['amount']);
+    }
+
+    /**
+     * @test
+     */
+    public function result_runs_a_funnel_widget(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $result = (new SigmieAnalyticsTool($index))->result(new Request([
+            'widget' => 'funnel',
+            'date_field' => 'created_at',
+            'steps' => '[{"label":"all","filter":"amount>0"},{"label":"big","filter":"amount>=100"}]',
+            'from' => '2024-01-01',
+            'to' => '2024-01-04',
+        ]));
+
+        $this->assertSame('funnel', $result['type']);
+        $this->assertSame(['all', 'big'], array_column($result['steps'], 'label'));
+        $this->assertEquals(5, $result['steps'][0]['count']);
+        $this->assertEquals(2, $result['steps'][1]['count']);
     }
 
     /**


### PR DESCRIPTION
## What

Fills the gaps in the analytics widget set and removes the single-window constraint that forced dashboards to split into extra queries.

### New widgets (`src/Analytics/Widgets/`)

| Widget | Computes | Backed by |
|---|---|---|
| **Table** | The actual matching documents — the rows behind a number, not a metric | `top_hits` |
| **StatSummary** | count / min / max / avg / sum of a numeric field in one tile | `stats` |
| **Funnel** | Ordered step conversion (visited → signed → paid) with overall **and** step-to-step rates | `filter` buckets |
| **Heatmap** | A dimension × dimension matrix, a metric per cell | nested `terms` |
| **Retention** | Cohort grid: entities grouped by cohort period, counted distinct across each later period | `date_histogram` + `cardinality` |
| **Geo** | A metric bucketed into geohash cells of a `geo_point` field | `geohash_grid` |

## What each widget looks like

**Table** — `->table('recent', fields: ['amount','product'], limit: 2, sort: 'amount:desc')`
```
recent  (top_hits)
┌────────────┬────────┬─────────┐
│ id         │ amount │ product │
├────────────┼────────┼─────────┤
│ ord_8f2c…  │    200 │ A       │
│ ord_3c91…  │    100 │ A       │
└────────────┴────────┴─────────┘
```

**StatSummary** — `->stats('order_size', 'amount')`
```
order_size  (stats)
┌───────────────────────────────┐
│  count 5            sum 450    │
│  min 30   max 200   avg 90     │
└───────────────────────────────┘
```

**Funnel** — `->funnel('signup', ['visited'=>…, 'signed'=>…, 'paid'=>…])`
```
signup  (filter buckets)
visited  ████████████████████  4   100%
signed   ██████████            2    50%   ↓ 50%
paid     █████                 1    25%   ↓ 50%
                                   └ vs first └ vs previous
```

**Heatmap** — `->heatmap('regions', 'region', 'device')`
```
regions  (region × device · count)
          mobile   desktop
   US  │   ▓▓ 2  │   ░ 1   │
   EU  │   ░  1  │     ·    │
```

**Retention** — `->retention('cohorts', 'signup_at', 'user', CalendarInterval::Day)`
```
cohorts  (cohort × period · distinct users)
cohort        size   d+0   d+1
2024-01-01     2      2     1
2024-01-02     1      ·     1
                      └ triangular: each cohort starts on its own day
```

**Geo** — `->geo('areas', 'location', precision: 5)`
```
areas  (geohash_grid · precision 5)
  ┌─────────────────────────────┐
  │   · · · · · · · · ● · · · ·  │   ● u173z…  2   (Amsterdam)
  │   · · ● · · · · · · · · · ·  │   ● dr5r0…  1   (New York)
  └─────────────────────────────┘   buckets sorted by count desc
```

### New aggregation
`Query\Aggregations\Bucket\GeoHashGrid` + `Aggs::geoHashGrid()` — the only new query-layer primitive, backing the Geo widget. Everything else reuses aggregations that already existed (notably `TopHits`, which had no widget before).

### Per-widget windows
A `window:` argument on every widget method lets a **single** `analytics()` call mix time windows — an all-time headline KPI next to a last-30-days trend — without a second request. It's the last argument alongside `filter:`, and takes a named `Period` or a `[$from, $to]` pair (resolved at construction, so `kpiDelta` computes its comparison window correctly):

```php
$index->analytics('created_at')
    ->from($from)->to($to)
    ->kpi('total', Metric::Sum, 'amount')                                    // analytics-wide window
    ->kpi('lifetime', Metric::Sum, 'amount', window: [$accountStart, $now])  // its own window
    ->trend('recent', Metric::Sum, 'amount', window: Period::Last30Days)     // a named period
    ->get();
```

```
total     ├──────────────── all-time ────────────────┤   Σ 450
recent                         ├─ last 30d ─┤   ╱╲__╱╲
          (one analytics() call, mixed windows, one request)
```

### AI tool coverage
The `analytics` agent tool (`SigmieAnalyticsTool`) exposes all 14 widgets — the six new ones included — each with a phrasing hint, a grounded example built from the index's own fields, and schema params (`fields`/`sort` for table, `steps` for funnel, `row_field`/`col_field` for heatmap, `cohort_field`/`id_field` for retention, `precision` for geo). So an agent can render any of them, not just the original eight.

### Single round-trip with multi-search
A dashboard can ride in a single `_msearch` alongside another query — most usefully a paginated, field-collapsed rows `search()` that can't be folded into aggregations (the hard wall `top_hits` can't cross). `Analytics` is now `MultiSearchable`, so `NewMultiSearch::newAnalytics()` starts a dashboard **inside** the batch and its response slot comes back already mapped to widget results:

```php
$multi = $sigmie->newMultiSearch();

$multi->newAnalytics($orders, 'created_at', 'metrics')              // the whole dashboard
    ->from($start)->to($end)
    ->kpiDelta('revenue', Metric::Sum, 'amount')
    ->trend('revenue_over_time', Metric::Sum, 'amount', CalendarInterval::Day);

$multi->newSearch($orders->name(), 'rows')->queryString('')->page(3, 20);  // paginated rows

[$metrics, $rows] = $multi->get();                                 // one HTTP round-trip
// $metrics is already the widget map
```

For a dashboard built elsewhere, `Analytics::toSearch()` + `NewMultiSearch::addQuery()` add it as a prebuilt query, and `Analytics::formatResponse()` maps that slot by hand.

```
┌──────────────── one _msearch ────────────────┐
│  metrics  → KPIs + trend (aggregations)       │
│  rows     → page 3 of paginated _source docs  │
└───────────────────────────────────────────────┘
```

## Why
The widget set returned aggregated numbers only — there was no way to surface the documents behind a slice (despite `top_hits` already being supported), no first-class funnel/cohort/heatmap/geo, and every widget was locked to one global window, which pushed real dashboards into multiple round-trips.

## Tests
Adds an `AnalyticsTest` case per widget plus the window override, using a generic throwaway-index helper. Integration tests run against a live cluster in CI.