### PR TITLE
fix(analytics): bare filter agg emits empty aggs; geo_point doc validation

### DIFF
--- a/src/Query/Aggregations/Bucket/Filter.php
+++ b/src/Query/Aggregations/Bucket/Filter.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Sigmie\Query\Aggregations\Bucket;
 
-use Sigmie\Query\Aggs;
-
 class Filter extends Bucket
 {
     public function __construct(
@@ -13,16 +11,19 @@ class Filter extends Bucket
         protected $query,
     ) {
         parent::__construct($name);
-        $this->aggs = new Aggs;
     }
 
+    /**
+     * Just the filter query — sub-aggregations are added by {@see Bucket::toRaw()} only when
+     * aggregate() set them, so a bare filter (e.g. a funnel step counting doc_count) doesn't emit
+     * an empty `aggs: []`, which Elasticsearch rejects.
+     */
     protected function value(): array
     {
         return [
             'filter' => [
                 ...$this->query->toRaw(),
             ],
-            'aggs' => $this->aggs->toRaw(),
         ];
     }
 }

--- a/src/Semantic/DocumentProcessor.php
+++ b/src/Semantic/DocumentProcessor.php
@@ -14,6 +14,7 @@ use Sigmie\Mappings\Types\BaseVector;
 use Sigmie\Mappings\Types\Combo;
 use Sigmie\Mappings\Types\Date;
 use Sigmie\Mappings\Types\DateTime;
+use Sigmie\Mappings\Types\GeoPoint;
 use Sigmie\Mappings\Types\Image;
 use Sigmie\Mappings\Types\Nested;
 use Sigmie\Mappings\Types\Number;
@@ -438,9 +439,10 @@ class DocumentProcessor
 
     protected function validateFieldValue(string $fieldPath, mixed $value, Type $field, array &$errors): void
     {
-        // For Range fields, the array IS the value (e.g., ['gt' => 10, 'lt' => 20])
-        // Don't iterate over it like we do for other field types
-        if ($field instanceof Range) {
+        // For Range and GeoPoint fields the array IS the value — a Range is ['gt' => 10, 'lt' => 20]
+        // and a GeoPoint is ['lat' => .., 'lon' => ..] (or a list of those). Validate it whole;
+        // iterating would recurse into the scalar lat/lon and reject them.
+        if ($field instanceof Range || $field instanceof GeoPoint) {
             [$isValid, $errorMessage] = $field->validate($fieldPath, $value);
 
             if (! $isValid) {


### PR DESCRIPTION
Fixes the test failures introduced by #88 (the analytics widgets PR) — both pre-existing edge cases that the new `funnel` and `geo` widgets are the first to hit.

## 1. Funnel — `filter` agg with no sub-aggregations
`Filter` pre-initialised an empty `Aggs` and always emitted `aggs` in its body, so a filter bucket with no sub-aggregations (a funnel step that only needs `doc_count`) serialised `aggs: []` — which Elasticsearch rejects:

> Expected [START_OBJECT] under [aggs], but got a [START_ARRAY] in [step_0]

`Filter` now leaves `aggs` to `Bucket::toRaw()`, which adds it only when `aggregate()` set sub-aggs — exactly like every other bucket. Filters **with** sub-aggs (the `scoped()` window, facets, …) are unchanged.

## 2. Geo — `geo_point` document validation
`validateFieldValue()` iterates array values into their items, then validates each. A `geo_point` value `['lat' => .., 'lon' => ..]` was iterated into the scalars `52.37` / `4.90`, which fail validation:

> The field location mapped as geo_point must have lat and lon keys.

`Range` already had a guard for "the array IS the value"; `GeoPoint` now shares it, so the point (a single `{lat,lon}` object or a list of them) is validated whole. No existing test indexed geo_point documents, so this was latent.

## Tests
Ran locally against a live cluster:
- The 3 previously failing tests pass.
- `AnalyticsTest` + `SigmieAnalyticsToolTest`: 34 passed.
- `AggregationTest` + `FacetsTest` + `FilterParserTest` + `MultiSearchTest` + …: 103 passed (the `Filter` change is exercised heavily by facets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)