### PR TITLE
Return hits with analytics widgets

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -339,9 +339,32 @@ $orders->analytics('created_at')->timezoneOffset(540)->range(Period::Last7Days);
 
 A **calendar** range also makes `kpiDelta` compare against the *previous instance* of that period rather than an equal-length window — `ThisMonth` → vs last calendar month, `ThisWeek` → vs last week. Raw `from()`/`to()` keep the equal-duration comparison.
 
+## Widgets and hits in one request
+
+`get()` returns only the widget map. When a dashboard needs the numbers **and** the matching documents behind those numbers, use `search()` to customize the underlying Elasticsearch search and `getWithHits()` to return both.
+
+```php
+$result = $orders->analytics('created_at')
+    ->from($start)->to($end)
+    ->kpi('revenue', Metric::Sum, 'amount')
+    ->search(function ($search) {
+        $search
+            ->size(20)
+            ->sort([['amount' => ['order' => 'desc']]])
+            ->postFilterString("status:'paid'")
+            ->trackTotalHits(true);
+    })
+    ->getWithHits();
+
+$result['widgets']['revenue']; // normalized KPI result
+$result['hits'];               // raw Elasticsearch hits block
+```
+
+The important detail is `post_filter`: it narrows the returned hits without changing the aggregations. That is useful when the headline card should count the full scoped population, but the table should show one row slice.
+
 ## One request with multi-search
 
-`get()` already runs every widget in a single request. But a dashboard often needs **one more** query that can't be expressed as an aggregation — most commonly a paginated, field-collapsed [`search()`](search.md) for a results table (`top_hits` only returns the top N of one bucket). Rather than pay a second round-trip, batch both into one `_msearch`.
+`get()` already runs every widget in a single request. `getWithHits()` covers the common case where the same search can return dashboard widgets and rows. When the rows need a completely different query shape, batch both into one `_msearch`.
 
 `newAnalytics()` starts a dashboard **inside** the multi-search — compose widgets on it as usual, and its response slot comes back already mapped to the widget result map:
 
@@ -368,7 +391,7 @@ $multi->addQuery($analytics->toSearch(), 'metrics');
 $dashboard = $analytics->formatResponse($metrics);
 ```
 
-`formatResponse()` maps the raw response's aggregations through every widget, exactly as `get()` does internally. Use `get()` for a standalone dashboard, and `newAnalytics()` (or `toSearch()` + `formatResponse()`) when it shares a request with another query.
+`formatResponse()` maps the raw response's aggregations through every widget, exactly as `get()` does internally. Use `get()` for a standalone dashboard, `getWithHits()` when one search can also return rows, and `newAnalytics()` (or `toSearch()` + `formatResponse()`) when analytics shares a round-trip with a separate query.
 
 ## Analytics for AI agents
 
@@ -391,4 +414,4 @@ public function tools(): array
 }
 ```
 
-The agent supplies the `date_field` (validated against the index's date fields), the `metric`/`field` (from its numeric fields), and optionally a `range` (`this_month`, `last_7_days`, …) and `timezone_offset` (minutes east of UTC) so charts land in the user's local time. As with the other tools, the optional `$baseFilter` is server-controlled scoping — AND-ed into every query and never taken from the agent — so an agent can only ever see its own slice of the data.
+The agent supplies the `date_field` (validated against the index's date fields), the `metric`/`field` (from its numeric fields), and optionally a `range` (`this_month`, `last_7_days`, …) and `timezone_offset` (minutes east of UTC) so charts land in the user's local time. When the user asks for a metric/chart and examples or rows behind it, the agent can set `include_hits=1`, plus optional `hit_fields`, `hit_sort`, `hit_limit`, and `hit_filters`. As with the other tools, the optional `$baseFilter` is server-controlled scoping — AND-ed into every query and never taken from the agent — so an agent can only ever see its own slice of the data.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -350,7 +350,7 @@ $result = $orders->analytics('created_at')
     ->search(function ($search) {
         $search
             ->size(20)
-            ->sort([['amount' => ['order' => 'desc']]])
+            ->sortString('amount:desc')
             ->postFilterString("status:'paid'")
             ->trackTotalHits(true);
     })

--- a/src/AI/SigmieAnalyticsTool.php
+++ b/src/AI/SigmieAnalyticsTool.php
@@ -193,7 +193,7 @@ class SigmieAnalyticsTool implements Tool
             'include_hits' => $schema->integer()->description('Set to 1 to return matching document hits alongside the widget from the same analytics search; pass null or 0 to omit hits')->default(0)->nullable()->required(),
             'hit_filters' => $schema->string()->description('Optional post-filter for returned hits only; keeps widget aggregations unchanged while narrowing rows (pass null for none)')->nullable()->required(),
             'hit_fields' => $schema->string()->description('Comma-separated source fields to include in returned hits when include_hits=1 (pass null for full source)')->nullable()->required(),
-            'hit_sort' => $schema->string()->description('Sort returned hits when include_hits=1 as "field:dir", e.g. "amount:desc" (pass null for Elasticsearch default)')->nullable()->required(),
+            'hit_sort' => $schema->string()->description('Sort returned hits when include_hits=1 using the search sort DSL, e.g. "amount:desc" or "_score" (pass null for Elasticsearch default)')->nullable()->required(),
             'hit_limit' => $schema->integer()->description('Number of document hits to return when include_hits=1, default 10')->default(10)->nullable()->required(),
         ];
     }
@@ -427,9 +427,9 @@ class SigmieAnalyticsTool implements Tool
                 $search->fields($fields);
             }
 
-            $sort = $this->hitSort($request);
-            if ($sort !== []) {
-                $search->sort($sort);
+            $sort = trim((string) ($request['hit_sort'] ?? ''));
+            if ($sort !== '') {
+                $search->sortString($sort);
             }
 
             $hitFilters = trim((string) ($request['hit_filters'] ?? ''));
@@ -437,33 +437,6 @@ class SigmieAnalyticsTool implements Tool
                 $search->postFilterString($hitFilters);
             }
         });
-    }
-
-    /**
-     * @return list<array<string, array{order: string}>>
-     */
-    protected function hitSort(Request $request): array
-    {
-        $raw = trim((string) ($request['hit_sort'] ?? ''));
-        if ($raw === '') {
-            return [];
-        }
-
-        return array_values(array_filter(array_map(function (string $part): ?array {
-            [$field, $direction] = array_pad(explode(':', trim($part), 2), 2, 'desc');
-            $field = trim($field);
-            $direction = strtolower(trim($direction));
-
-            if ($field === '') {
-                return null;
-            }
-
-            if (! in_array($direction, ['asc', 'desc'], true)) {
-                throw new InvalidArgumentException(sprintf("Unknown hit_sort direction '%s'. Use asc or desc.", $direction));
-            }
-
-            return [$field => ['order' => $direction]];
-        }, preg_split('/\s+/', $raw) ?: [])));
     }
 
     /**

--- a/src/AI/SigmieAnalyticsTool.php
+++ b/src/AI/SigmieAnalyticsTool.php
@@ -14,6 +14,7 @@ use Sigmie\Analytics\Analytics;
 use Sigmie\Analytics\Enums\Metric;
 use Sigmie\Analytics\Enums\Period;
 use Sigmie\Query\Aggregations\Enums\CalendarInterval;
+use Sigmie\Query\Search;
 use Sigmie\SigmieIndex;
 
 /**
@@ -114,6 +115,7 @@ class SigmieAnalyticsTool implements Tool
 
         $description .= "\n\nTime window: `from` and `to` are ISO dates (default: last 30 days).\n"
             ."Narrow with `filters` (same DSL as the search tool, e.g. \"status:'paid' AND amount>10\") — it scopes this widget to that slice of the window. Call describe_index for the full field list and filter syntax.\n"
+            ."Need a number/chart and the matching rows in one call? Set `include_hits` to 1. Use `hit_filters` when the rows should be narrower than the widget, `hit_fields` to choose source fields, `hit_sort` to order rows, and `hit_limit` for row count.\n"
             .'Comparing slices: for an ordered funnel (total → engaged → completed) use the funnel widget with `steps`; for an ad-hoc A vs B, call this tool once per slice over the SAME window — each call narrows with its own `filters` — and read the numbers side by side.';
 
         return $description."\n\nExamples (`widget` → arguments):\n".$this->examples();
@@ -149,6 +151,7 @@ class SigmieAnalyticsTool implements Tool
             'weekly cohort retention' => ['widget' => 'retention', 'date_field' => $date, 'cohort_field' => $date, 'id_field' => $keyword, 'interval' => 'week', 'range' => 'last_90_days'],
             'counts on a map' => ['widget' => 'geo', 'date_field' => $date, 'field' => $geo, 'precision' => 5, 'range' => 'this_month'],
             'one slice of the window' => ['widget' => 'kpi', 'date_field' => $date, 'metric' => 'sum', 'field' => $number, 'filters' => sprintf("%s:'…'", $keyword), 'range' => 'this_month'],
+            'number plus rows' => ['widget' => 'kpi', 'date_field' => $date, 'metric' => 'sum', 'field' => $number, 'range' => 'this_month', 'include_hits' => 1, 'hit_fields' => sprintf('%s,%s', $keyword, $number), 'hit_sort' => $number.':desc', 'hit_limit' => 5],
         ];
 
         $lines = array_map(
@@ -187,6 +190,11 @@ class SigmieAnalyticsTool implements Tool
             'from' => $schema->string()->description('ISO start date, inclusive — ignored when range is set (pass null for 30 days ago)')->nullable()->required(),
             'to' => $schema->string()->description('ISO end date, exclusive — ignored when range is set (pass null for now)')->nullable()->required(),
             'filters' => $schema->string()->description('Filter expression, same DSL as the search tool — scopes this widget to a slice of the window (pass null for none)')->nullable()->required(),
+            'include_hits' => $schema->integer()->description('Set to 1 to return matching document hits alongside the widget from the same analytics search; pass null or 0 to omit hits')->default(0)->nullable()->required(),
+            'hit_filters' => $schema->string()->description('Optional post-filter for returned hits only; keeps widget aggregations unchanged while narrowing rows (pass null for none)')->nullable()->required(),
+            'hit_fields' => $schema->string()->description('Comma-separated source fields to include in returned hits when include_hits=1 (pass null for full source)')->nullable()->required(),
+            'hit_sort' => $schema->string()->description('Sort returned hits when include_hits=1 as "field:dir", e.g. "amount:desc" (pass null for Elasticsearch default)')->nullable()->required(),
+            'hit_limit' => $schema->integer()->description('Number of document hits to return when include_hits=1, default 10')->default(10)->nullable()->required(),
         ];
     }
 
@@ -227,6 +235,17 @@ class SigmieAnalyticsTool implements Tool
         }
 
         $this->build($analytics, $widget, $request);
+
+        if ($this->includeHits($request)) {
+            $this->configureHits($analytics, $request);
+
+            $result = $analytics->getWithHits();
+
+            return [
+                'result' => $result['widgets']['result'] ?? [],
+                'hits' => $result['hits'],
+            ];
+        }
 
         return $analytics->get()['result'] ?? [];
     }
@@ -387,6 +406,64 @@ class SigmieAnalyticsTool implements Tool
             array_map(static fn (string $v): string => trim($v), explode(',', $raw)),
             static fn (string $v): bool => $v !== '',
         ));
+    }
+
+    protected function includeHits(Request $request): bool
+    {
+        return (int) ($request['include_hits'] ?? 0) === 1;
+    }
+
+    protected function configureHits(Analytics $analytics, Request $request): void
+    {
+        $analytics->search(function (Search $search) use ($request): void {
+            $limit = max(1, (int) ($request['hit_limit'] ?? 10));
+
+            $search
+                ->size($limit)
+                ->trackTotalHits(true);
+
+            $fields = $this->csvList($request, 'hit_fields');
+            if ($fields !== []) {
+                $search->fields($fields);
+            }
+
+            $sort = $this->hitSort($request);
+            if ($sort !== []) {
+                $search->sort($sort);
+            }
+
+            $hitFilters = trim((string) ($request['hit_filters'] ?? ''));
+            if ($hitFilters !== '') {
+                $search->postFilterString($hitFilters);
+            }
+        });
+    }
+
+    /**
+     * @return list<array<string, array{order: string}>>
+     */
+    protected function hitSort(Request $request): array
+    {
+        $raw = trim((string) ($request['hit_sort'] ?? ''));
+        if ($raw === '') {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(function (string $part): ?array {
+            [$field, $direction] = array_pad(explode(':', trim($part), 2), 2, 'desc');
+            $field = trim($field);
+            $direction = strtolower(trim($direction));
+
+            if ($field === '') {
+                return null;
+            }
+
+            if (! in_array($direction, ['asc', 'desc'], true)) {
+                throw new InvalidArgumentException(sprintf("Unknown hit_sort direction '%s'. Use asc or desc.", $direction));
+            }
+
+            return [$field => ['order' => $direction]];
+        }, preg_split('/\s+/', $raw) ?: [])));
     }
 
     /**

--- a/src/Analytics/Analytics.php
+++ b/src/Analytics/Analytics.php
@@ -393,7 +393,7 @@ class Analytics implements MultiSearchable
 
     /**
      * Run the analytics search and return both normalized widgets and the raw Elasticsearch hits block.
-     * Use {@see search()} to configure hit pagination, sorting, collapse, post_filter, and total hits.
+     * Use {@see Search()} to configure hit pagination, sorting, collapse, post_filter, and total hits.
      *
      * @return array{widgets: array<string, mixed>, hits: array<string, mixed>, took: int|null, timed_out: bool}
      */

--- a/src/Analytics/Analytics.php
+++ b/src/Analytics/Analytics.php
@@ -83,6 +83,11 @@ class Analytics implements MultiSearchable
 
     protected ?Properties $resolvedProperties = null;
 
+    /**
+     * @var list<callable(Search): void>
+     */
+    protected array $searchCallbacks = [];
+
     public function __construct(
         protected NewQuery $query,
         protected NewProperties $properties,
@@ -142,6 +147,19 @@ class Analytics implements MultiSearchable
     public function filterQuery(QueryClause $query): static
     {
         $this->filterQueries[] = $query;
+
+        return $this;
+    }
+
+    /**
+     * Customize the underlying Elasticsearch search used for this dashboard. This lets callers fetch
+     * document hits and aggregations from the same request by overriding the default size(0), adding a
+     * post_filter for rows, sorting, collapsing, tracking totals, or attaching raw search options.
+     */
+    public function search(callable $callback): static
+    {
+        $this->searchCallbacks[] = $callback;
+        $this->compiledSearch = null;
 
         return $this;
     }
@@ -374,6 +392,19 @@ class Analytics implements MultiSearchable
     }
 
     /**
+     * Run the analytics search and return both normalized widgets and the raw Elasticsearch hits block.
+     * Use {@see search()} to configure hit pagination, sorting, collapse, post_filter, and total hits.
+     *
+     * @return array{widgets: array<string, mixed>, hits: array<string, mixed>, took: int|null, timed_out: bool}
+     */
+    public function getWithHits(): array
+    {
+        $response = $this->compile()->response()->json() ?? [];
+
+        return $this->formatResponseWithHits($response);
+    }
+
+    /**
      * Turn a raw search response into the map of widget name => normalised result. Public so a
      * multi-search caller that batched {@see toSearch()} into one _msearch can format that response
      * slot directly, instead of going through {@see get()} (which runs its own request).
@@ -381,6 +412,21 @@ class Analytics implements MultiSearchable
     public function formatResponse(array $response): array
     {
         return $this->mapWidgets($response['aggregations'] ?? []);
+    }
+
+    /**
+     * Format a raw search response when the analytics request also fetches document hits.
+     *
+     * @return array{widgets: array<string, mixed>, hits: array<string, mixed>, took: int|null, timed_out: bool}
+     */
+    public function formatResponseWithHits(array $response): array
+    {
+        return [
+            'widgets' => $this->formatResponse($response),
+            'hits' => $response['hits'] ?? [],
+            'took' => $response['took'] ?? null,
+            'timed_out' => $response['timed_out'] ?? false,
+        ];
     }
 
     /**
@@ -443,7 +489,11 @@ class Analytics implements MultiSearchable
      */
     protected function compile(): Search
     {
-        return $this->compiledSearch ??= $this->query
+        if ($this->compiledSearch instanceof Search) {
+            return $this->compiledSearch;
+        }
+
+        $search = $this->query
             ->properties($this->properties)
             ->bool(function (Boolean $boolean): void {
                 $filter = $boolean->filter();
@@ -460,6 +510,12 @@ class Analytics implements MultiSearchable
                     $aggs->add($widget);
                 }
             });
+
+        foreach ($this->searchCallbacks as $callback) {
+            $callback($search);
+        }
+
+        return $this->compiledSearch = $search;
     }
 
     /**

--- a/src/Query/Search.php
+++ b/src/Query/Search.php
@@ -249,7 +249,6 @@ class Search
     public function toRaw(): array
     {
         $result = [
-            '_source' => $this->fields,
             'query' => $this->query->toRaw(),
             'from' => $this->from,
             'size' => $this->size,
@@ -257,6 +256,10 @@ class Search
             'sort' => $this->sort,
             ...$this->raw,
         ];
+
+        if ($this->fields !== []) {
+            $result['_source'] = $this->fields;
+        }
 
         if ($this->knn !== []) {
             $result['knn'] = $this->knn;

--- a/src/Query/Search.php
+++ b/src/Query/Search.php
@@ -10,6 +10,7 @@ use Sigmie\Base\Contracts\ElasticsearchConnection;
 use Sigmie\Base\Http\Responses\Search as SearchResponse;
 use Sigmie\Mappings\Properties;
 use Sigmie\Parse\FilterParser;
+use Sigmie\Parse\SortParser;
 use Sigmie\Query\Contracts\QueryClause as Query;
 use Sigmie\Query\Queries\MatchAll;
 
@@ -174,6 +175,13 @@ class Search
         $this->sort = $sort;
 
         return $this;
+    }
+
+    public function sortString(string $sort): static
+    {
+        $parser = new SortParser($this->filterParserProperties ?? new Properties);
+
+        return $this->sort($parser->parse($sort));
     }
 
     public function addRaw(string $key, mixed $value): static

--- a/tests/AnalyticsTest.php
+++ b/tests/AnalyticsTest.php
@@ -306,7 +306,7 @@ class AnalyticsTest extends TestCase
             ->search(function (Search $search): void {
                 $search
                     ->size(2)
-                    ->sort([['amount' => ['order' => 'desc']]])
+                    ->sortString('amount:desc')
                     ->postFilterString("product:'A'")
                     ->trackTotalHits(true);
             })

--- a/tests/AnalyticsTest.php
+++ b/tests/AnalyticsTest.php
@@ -14,6 +14,7 @@ use Sigmie\Mappings\NewProperties;
 use Sigmie\Query\Aggregations\Enums\CalendarInterval;
 use Sigmie\Query\Queries\Term\Range;
 use Sigmie\Query\Queries\Term\Term;
+use Sigmie\Query\Search;
 use Sigmie\Sigmie;
 use Sigmie\SigmieIndex;
 use Sigmie\Testing\TestCase;
@@ -289,6 +290,33 @@ class AnalyticsTest extends TestCase
 
         // amounts >= 100: 100 + 200 = 300
         $this->assertEquals(300.0, $result['revenue']['value']);
+    }
+
+    /**
+     * @test
+     */
+    public function analytics_can_return_widgets_and_hits_from_one_search(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $result = $index->analytics('created_at')
+            ->from($this->date('2024-01-01'))
+            ->to($this->date('2024-01-04'))
+            ->kpi('revenue', Metric::Sum, 'amount')
+            ->search(function (Search $search): void {
+                $search
+                    ->size(2)
+                    ->sort([['amount' => ['order' => 'desc']]])
+                    ->postFilterString("product:'A'")
+                    ->trackTotalHits(true);
+            })
+            ->getWithHits();
+
+        $this->assertEquals(450.0, $result['widgets']['revenue']['value']);
+        $this->assertSame(3, $result['hits']['total']['value']);
+        $this->assertCount(2, $result['hits']['hits']);
+        $this->assertSame(200, $result['hits']['hits'][0]['_source']['amount']);
+        $this->assertSame('A', $result['hits']['hits'][0]['_source']['product']);
     }
 
     /**

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -284,15 +284,35 @@ class QueryTest extends TestCase
      */
     public function search_dsl_only_filters_source_when_fields_are_explicit(): void
     {
-        $query = $this->sigmie->newQuery('')->getDSL();
+        $query = $this->sigmie->newQuery('')
+            ->matchAll()
+            ->getDSL();
 
         $this->assertArrayNotHasKey('_source', $query);
 
         $query = $this->sigmie->newQuery('')
+            ->matchAll()
             ->fields(['title'])
             ->getDSL();
 
         $this->assertSame(['title'], $query['_source']);
+    }
+
+    /**
+     * @test
+     */
+    public function low_level_search_can_parse_sort_strings_with_query_properties(): void
+    {
+        $props = new NewProperties;
+        $props->text('title')->keyword()->makeSortable();
+
+        $query = $this->sigmie->newQuery('')
+            ->properties($props)
+            ->matchAll()
+            ->sortString('title:desc')
+            ->getDSL();
+
+        $this->assertSame([['title.sortable' => 'desc']], $query['sort']);
     }
 
     /**

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -282,6 +282,22 @@ class QueryTest extends TestCase
     /**
      * @test
      */
+    public function search_dsl_only_filters_source_when_fields_are_explicit(): void
+    {
+        $query = $this->sigmie->newQuery('')->getDSL();
+
+        $this->assertArrayNotHasKey('_source', $query);
+
+        $query = $this->sigmie->newQuery('')
+            ->fields(['title'])
+            ->getDSL();
+
+        $this->assertSame(['title'], $query['_source']);
+    }
+
+    /**
+     * @test
+     */
     public function match_query_analyzer(): void
     {
         $query = $this->sigmie

--- a/tests/SigmieAnalyticsToolTest.php
+++ b/tests/SigmieAnalyticsToolTest.php
@@ -92,6 +92,8 @@ class SigmieAnalyticsToolTest extends TestCase
         $this->assertStringContainsString('created_at', $description);
         $this->assertStringContainsString('amount', $description);
         $this->assertStringContainsString('median', $description);
+        $this->assertStringContainsString('include_hits', $description);
+        $this->assertStringContainsString('hit_filters', $description);
     }
 
     /**
@@ -168,7 +170,7 @@ class SigmieAnalyticsToolTest extends TestCase
         $this->assertFalse($schema['widget']->nullable, "'widget' must NOT be nullable.");
         $this->assertFalse($schema['date_field']->nullable, "'date_field' must NOT be nullable.");
 
-        foreach (['metric', 'field', 'interval', 'group_by', 'limit', 'bucket_size', 'percents', 'from', 'to', 'filters'] as $name) {
+        foreach (['metric', 'field', 'interval', 'group_by', 'limit', 'bucket_size', 'percents', 'from', 'to', 'filters', 'include_hits', 'hit_filters', 'hit_fields', 'hit_sort', 'hit_limit'] as $name) {
             $this->assertTrue($schema[$name]->nullable, sprintf("Optional property '%s' must be nullable().", $name));
         }
     }
@@ -257,6 +259,34 @@ class SigmieAnalyticsToolTest extends TestCase
         $this->assertSame('table', $result['type']);
         $this->assertCount(2, $result['rows']);
         $this->assertEquals(200, $result['rows'][0]['document']['amount']);
+    }
+
+    /**
+     * @test
+     */
+    public function result_can_return_a_widget_and_document_hits(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $result = (new SigmieAnalyticsTool($index))->result(new Request([
+            'widget' => 'kpi',
+            'date_field' => 'created_at',
+            'metric' => 'sum',
+            'field' => 'amount',
+            'from' => '2024-01-01',
+            'to' => '2024-01-04',
+            'include_hits' => 1,
+            'hit_fields' => 'amount,product',
+            'hit_sort' => 'amount:desc',
+            'hit_filters' => "product:'A'",
+            'hit_limit' => 2,
+        ]));
+
+        $this->assertEquals(450.0, $result['result']['value']);
+        $this->assertSame(3, $result['hits']['total']['value']);
+        $this->assertCount(2, $result['hits']['hits']);
+        $this->assertSame(200, $result['hits']['hits'][0]['_source']['amount']);
+        $this->assertSame('A', $result['hits']['hits'][0]['_source']['product']);
     }
 
     /**


### PR DESCRIPTION
## What

Analytics dashboards can now return normalized widgets and matching document hits from one Elasticsearch `_search`.

## Context

Canopy needs one ES report request that can compute KPIs/trends and retrieve the rows behind the report without `_msearch` or a second raw query. Elasticsearch can return top-level `hits` and `aggregations` together; Sigmie's Analytics API previously normalized only the aggregation side.

## Breakdown

- `Analytics::search()` lets callers customize the underlying `Search` body after widgets compile.
- `Analytics::getWithHits()` returns both:
  - `widgets`: the existing normalized widget map
  - `hits`: the raw Elasticsearch hits block from the same response
- `Search::sortString()` now exposes the existing `SortParser` on the lower-level search object, so analytics callbacks and AI hit sorting use the same mapped sort DSL as `NewQuery`.
- `Search::postFilterString()` continues to use the existing `FilterParser`; analytics now passes query properties into the compiled search so callback filters and sorts are mapping-aware.
- `SigmieAnalyticsTool` now exposes `include_hits`, `hit_filters`, `hit_fields`, `hit_sort`, and `hit_limit` so AI agents can ask for a metric/chart plus matching rows in one analytics call.
- `Search` now omits `_source` unless fields are explicitly selected, so omitted `hit_fields` means Elasticsearch returns full source documents.
- Docs now explain the one-search widget-plus-hits flow and when to use `post_filter`.

## Visual

```text
Before

Analytics::get()
  -> one _search
      -> aggregations
      -> normalized widgets

Rows needed a second query or _msearch.

After

Analytics::search(...)->getWithHits()
  -> one _search
      -> query/filter scope
      -> aggs          -> normalized widgets
      -> post_filter   -> hits-only row narrowing
      -> top-level hits -> rows/examples
```

## Why Not `top_hits` Inside Buckets?

Elasticsearch does support `top_hits` inside aggregation buckets, and filter aggs can contain bool queries. That makes sense when the UI needs "top documents per bucket", such as top orders per product or latest events per day.

That is not the best fit for Canopy's open-rates/report table. The table is a single globally sorted/paginated row set, often narrowed independently from the dashboard metrics. Putting rows inside aggregation buckets would turn pagination, total hit counts, sorting, and field collapsing into bucket-local behavior instead of table behavior.

So this PR keeps metrics in aggregations and rows in top-level `hits`. When rows need to be narrower than the metric, `post_filter` narrows only the hits while leaving aggregations unchanged.

## API Note

`getWithHits()` is intentionally separate from `get()` so the existing widget-only return shape stays unchanged. If we want a different public name before merge, the closest alternatives are likely `getWithSearch()` or `getResponse()`, but both are less explicit that the extra payload is the top-level Elasticsearch hits block.

## Verification

- `php -l src/Analytics/Analytics.php`
- `php -l src/AI/SigmieAnalyticsTool.php`
- `php -l src/Query/Search.php`
- `php -l tests/AnalyticsTest.php`
- `php -l tests/QueryTest.php`
- `php -l tests/SigmieAnalyticsToolTest.php`
- `git diff --check`
- `vendor/bin/phpunit --filter "search_dsl_only_filters_source_when_fields_are_explicit|low_level_search_can_parse_sort_strings_with_query_properties|sort_string_parses_and_sorts_results" tests/QueryTest.php`
- `vendor/bin/phpunit --filter "analytics_can_return_widgets_and_hits_from_one_search" tests/AnalyticsTest.php`
- `vendor/bin/phpunit --filter "result_can_return_a_widget_and_document_hits|schema_marks_required_and_optional_params_for_openai_strict|description_lists_widgets_metrics_and_timeline_fields" tests/SigmieAnalyticsToolTest.php`