### PR TITLE
[codex] Add scripted metric aggregation

### DIFF
--- a/src/Query/Aggregations/Metrics/ScriptedMetric.php
+++ b/src/Query/Aggregations/Metrics/ScriptedMetric.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\Query\Aggregations\Metrics;
+
+use Sigmie\Query\Contracts\Aggregation;
+use Sigmie\Query\Shared\Meta;
+
+class ScriptedMetric implements Aggregation
+{
+    use Meta;
+
+    /**
+     * @param  array<string, mixed>  $params
+     */
+    public function __construct(
+        protected string $name,
+        protected string $initScript,
+        protected string $mapScript,
+        protected string $combineScript,
+        protected string $reduceScript,
+        protected array $params = [],
+    ) {}
+
+    public function toRaw(): array
+    {
+        $scriptedMetric = [
+            'init_script' => $this->initScript,
+            'map_script' => $this->mapScript,
+            'combine_script' => $this->combineScript,
+            'reduce_script' => $this->reduceScript,
+        ];
+
+        if ($this->params !== []) {
+            $scriptedMetric['params'] = $this->params;
+        }
+
+        $raw = [
+            $this->name => [
+                'scripted_metric' => $scriptedMetric,
+            ],
+        ];
+
+        if ($this->meta !== []) {
+            $raw[$this->name]['meta'] = [
+                ...$this->meta,
+            ];
+        }
+
+        return $raw;
+    }
+}

--- a/src/Query/Aggs.php
+++ b/src/Query/Aggs.php
@@ -29,6 +29,7 @@ use Sigmie\Query\Aggregations\Metrics\Min;
 use Sigmie\Query\Aggregations\Metrics\PercentileRanks;
 use Sigmie\Query\Aggregations\Metrics\Percentiles;
 use Sigmie\Query\Aggregations\Metrics\Rate;
+use Sigmie\Query\Aggregations\Metrics\ScriptedMetric;
 use Sigmie\Query\Aggregations\Metrics\Stats;
 use Sigmie\Query\Aggregations\Metrics\Sum;
 use Sigmie\Query\Aggregations\Metrics\TopHits;
@@ -213,6 +214,31 @@ class Aggs implements AggsInterface
         ?array $sort = null,
     ): TopHits {
         $aggregation = new TopHits($name, $sort, $sourceIncludes, $size);
+
+        $this->aggs[] = $aggregation;
+
+        return $aggregation;
+    }
+
+    /**
+     * @param  array<string, mixed>  $params
+     */
+    public function scriptedMetric(
+        string $name,
+        string $initScript,
+        string $mapScript,
+        string $combineScript,
+        string $reduceScript,
+        array $params = [],
+    ): ScriptedMetric {
+        $aggregation = new ScriptedMetric(
+            $name,
+            $initScript,
+            $mapScript,
+            $combineScript,
+            $reduceScript,
+            $params,
+        );
 
         $this->aggs[] = $aggregation;
 

--- a/tests/AggregationTest.php
+++ b/tests/AggregationTest.php
@@ -203,6 +203,36 @@ class AggregationTest extends TestCase
     /**
      * @test
      */
+    public function scripted_metric_aggregation(): void
+    {
+        $aggregation = new SearchAggregation;
+
+        $aggregation->scriptedMetric(
+            'latest_status',
+            'state.rows = [:];',
+            'state.rows[doc["id"].value] = doc["status"].value;',
+            'return state.rows;',
+            'return states;',
+            ['status' => 'completed'],
+        )->meta(['scope' => 'report']);
+
+        $this->assertEquals([
+            'latest_status' => [
+                'scripted_metric' => [
+                    'init_script' => 'state.rows = [:];',
+                    'map_script' => 'state.rows[doc["id"].value] = doc["status"].value;',
+                    'combine_script' => 'return state.rows;',
+                    'reduce_script' => 'return states;',
+                    'params' => ['status' => 'completed'],
+                ],
+                'meta' => ['scope' => 'report'],
+            ],
+        ], $aggregation->toRaw());
+    }
+
+    /**
+     * @test
+     */
     public function date_histogram_aggregation(): void
     {
         $name = uniqid();


### PR DESCRIPTION
## Summary
- Adds a ScriptedMetric aggregation class for Elasticsearch scripted_metric aggregations.
- Adds Aggs::scriptedMetric() as the fluent Sigmie abstraction for building it.
- Covers the raw aggregation shape, params, and meta handling in AggregationTest.

## Why
Reports that need exact latest-state calculations may need Elasticsearch-side scripted_metric aggregations while still going through Sigmie query abstractions instead of raw Elasticsearch query arrays.

## Validation
- /opt/homebrew/bin/php -l src/Query/Aggregations/Metrics/ScriptedMetric.php
- /opt/homebrew/bin/php -l src/Query/Aggs.php
- /opt/homebrew/bin/php -l tests/AggregationTest.php

Tests were not run.