### PR TITLE
[codex] Add breakdown bucket aliases

### DIFF
--- a/src/AI/SigmieAnalyticsTool.php
+++ b/src/AI/SigmieAnalyticsTool.php
@@ -95,6 +95,8 @@ class SigmieAnalyticsTool implements Tool
             ."- \"retention\", \"cohort analysis\", \"how many users come back\" → retention\n"
             .'- "on a map", "by location / area / region (coordinates)", "geo heatmap" → geo';
 
+        $description .= "\n\nBucket aliases: for breakdowns, use `bucket_aliases` only when the user explicitly asks to merge exact bucket labels, e.g. [{\"label\":\"Germany\",\"values\":[\"Germany\",\"West Germany\"]}].";
+
         $description .= "\n\nMetrics (`metric`): sum, avg, min, max, count, unique (distinct), median.";
         $description .= "\n\nIntervals (`interval`): a calendar unit (minute, hour, day, week, month, quarter, year) or a fixed interval — a multiple of a unit like 15d, 12h, 90m, 30s.";
         $description .= "\n\nRelative window (`range`, preferred over from/to): today, yesterday, this_week, last_week, this_month, last_month, this_quarter, last_quarter, this_year, last_year, last_7_days, last_30_days, last_90_days. A calendar range makes kpi_delta compare against the previous instance (this_month vs last_month).";
@@ -142,6 +144,7 @@ class SigmieAnalyticsTool implements Tool
             'running total this quarter' => ['widget' => 'cumulative', 'date_field' => $date, 'metric' => 'sum', 'field' => $number, 'interval' => 'day', 'range' => 'this_quarter'],
             'daily series per group' => ['widget' => 'grouped_trend', 'date_field' => $date, 'metric' => 'sum', 'field' => $number, 'group_by' => $keyword, 'interval' => 'day', 'range' => 'last_30_days'],
             'top 5 groups by total' => ['widget' => 'breakdown', 'date_field' => $date, 'group_by' => $keyword, 'metric' => 'sum', 'field' => $number, 'limit' => 5, 'range' => 'this_month'],
+            'top groups with merged labels' => ['widget' => 'breakdown', 'date_field' => $date, 'group_by' => $keyword, 'metric' => 'sum', 'field' => $number, 'limit' => 5, 'range' => 'this_month', 'bucket_aliases' => '[{"label":"Combined","values":["Old name","New name"]}]'],
             'histogram of a number' => ['widget' => 'distribution', 'date_field' => $date, 'field' => $number, 'bucket_size' => 100, 'range' => 'this_month'],
             'p50/p95/p99 of a number' => ['widget' => 'percentiles', 'date_field' => $date, 'field' => $number, 'percents' => '50,95,99', 'range' => 'this_month'],
             'summary of a number' => ['widget' => 'stats', 'date_field' => $date, 'field' => $number, 'range' => 'this_month'],
@@ -190,6 +193,7 @@ class SigmieAnalyticsTool implements Tool
             'from' => $schema->string()->description('ISO start date, inclusive — ignored when range is set (pass null for 30 days ago)')->nullable()->required(),
             'to' => $schema->string()->description('ISO end date, exclusive — ignored when range is set (pass null for now)')->nullable()->required(),
             'filters' => $schema->string()->description('Filter expression, same DSL as the search tool — scopes this widget to a slice of the window (pass null for none)')->nullable()->required(),
+            'bucket_aliases' => $schema->string()->description('JSON array for breakdown bucket merges, e.g. [{"label":"Germany","values":["Germany","West Germany"]}]. Use only when the user explicitly asks to combine exact labels; pass null otherwise')->nullable()->required(),
             'include_hits' => $schema->integer()->description('Set to 1 to return matching document hits alongside the widget from the same analytics search; pass null or 0 to omit hits')->default(0)->nullable()->required(),
             'hit_filters' => $schema->string()->description('Optional post-filter for returned hits only; keeps widget aggregations unchanged while narrowing rows (pass null for none)')->nullable()->required(),
             'hit_fields' => $schema->string()->description('Comma-separated source fields to include in returned hits when include_hits=1 (pass null for full source)')->nullable()->required(),
@@ -264,7 +268,7 @@ class SigmieAnalyticsTool implements Tool
             'trend' => $analytics->trend('result', $metric(), $field, $interval()),
             'cumulative' => $analytics->cumulative('result', $metric(), $field, $interval()),
             'grouped_trend' => $analytics->groupedTrend('result', $metric(), $this->required($request, 'field'), $groupBy(), $interval(), $limit),
-            'breakdown' => $analytics->breakdown('result', $groupBy(), $metric(), $field, $limit),
+            'breakdown' => $analytics->breakdown('result', $groupBy(), $metric(), $field, $limit, bucketAliases: $this->bucketAliases($request)),
             'distribution' => $analytics->distribution('result', $this->required($request, 'field'), (int) ($request['bucket_size'] ?? throw new InvalidArgumentException('The distribution widget requires bucket_size.'))),
             'percentiles' => $analytics->percentiles('result', $this->required($request, 'field'), $this->percents($request)),
             'stats' => $analytics->stats('result', $this->required($request, 'field')),
@@ -411,6 +415,46 @@ class SigmieAnalyticsTool implements Tool
     protected function includeHits(Request $request): bool
     {
         return (int) ($request['include_hits'] ?? 0) === 1;
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    protected function bucketAliases(Request $request): array
+    {
+        $raw = trim((string) ($request['bucket_aliases'] ?? ''));
+
+        if ($raw === '') {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+
+        if (! is_array($decoded)) {
+            throw new InvalidArgumentException('bucket_aliases must be a JSON array of {label, values} objects.');
+        }
+
+        $aliases = [];
+
+        foreach ($decoded as $item) {
+            if (! is_array($item)) {
+                throw new InvalidArgumentException('Each bucket_aliases item must be an object with label and values.');
+            }
+
+            $label = trim((string) ($item['label'] ?? ''));
+            $values = array_values(array_filter(array_map(
+                static fn (mixed $value): string => trim((string) $value),
+                (array) ($item['values'] ?? []),
+            ), static fn (string $value): bool => $value !== ''));
+
+            if ($label === '' || $values === []) {
+                throw new InvalidArgumentException('Each bucket_aliases item needs a non-empty label and values array.');
+            }
+
+            $aliases[$label] = $values;
+        }
+
+        return $aliases;
     }
 
     protected function configureHits(Analytics $analytics, Request $request): void

--- a/src/AI/SigmieAnalyticsTool.php
+++ b/src/AI/SigmieAnalyticsTool.php
@@ -67,6 +67,7 @@ class SigmieAnalyticsTool implements Tool
             ."- cumulative: running total over time — growth curve (needs metric, field, interval)\n"
             ."- grouped_trend: one trend line per value of group_by — stacked chart (needs metric, field, group_by, interval)\n"
             ."- breakdown: top-N group_by values ranked by a metric (needs group_by, metric, field)\n"
+            ."- multi_breakdown: top-N combinations of group_by_fields ranked by a metric (needs group_by_fields, metric, field)\n"
             ."- distribution: histogram of a numeric field (needs field, bucket_size)\n"
             ."- percentiles: p50/p75/p95/p99 of a numeric field (needs field)\n"
             ."- stats: count/min/max/avg/sum of a numeric field in one tile (needs field)\n"
@@ -85,6 +86,7 @@ class SigmieAnalyticsTool implements Tool
             ."- \"X over time\", \"trend of X\", \"X by <date_field>\" → trend\n"
             ."- \"running total\", \"cumulative X\", \"growth curve\" → cumulative\n"
             ."- \"top N <thing> by X\", \"best <thing>\", \"which <thing> drove the most X\" → breakdown (group_by=<thing>)\n"
+            ."- \"top N <thing> by <dimension> by X\", \"best <dim1> + <dim2> combinations\", \"rank combinations\" -> multi_breakdown (group_by_fields=<dim1>,<dim2>)\n"
             ."- \"X this month\" / \"average X last week\" with no bucket word → kpi (or kpi_delta when the user compares to a prior period)\n"
             ."- \"distribution of X\", \"histogram of X\" → distribution\n"
             ."- \"p50/p75/p95/p99\", \"percentiles of X\", \"median X\" → percentiles\n"
@@ -145,6 +147,7 @@ class SigmieAnalyticsTool implements Tool
             'daily series per group' => ['widget' => 'grouped_trend', 'date_field' => $date, 'metric' => 'sum', 'field' => $number, 'group_by' => $keyword, 'interval' => 'day', 'range' => 'last_30_days'],
             'top 5 groups by total' => ['widget' => 'breakdown', 'date_field' => $date, 'group_by' => $keyword, 'metric' => 'sum', 'field' => $number, 'limit' => 5, 'range' => 'this_month'],
             'top groups with merged labels' => ['widget' => 'breakdown', 'date_field' => $date, 'group_by' => $keyword, 'metric' => 'sum', 'field' => $number, 'limit' => 5, 'range' => 'this_month', 'bucket_aliases' => '[{"label":"Combined","values":["Old name","New name"]}]'],
+            'top combinations by total' => ['widget' => 'multi_breakdown', 'date_field' => $date, 'group_by_fields' => sprintf('%s,%s', $keyword, $keyword2), 'metric' => 'sum', 'field' => $number, 'limit' => 5, 'range' => 'this_month'],
             'histogram of a number' => ['widget' => 'distribution', 'date_field' => $date, 'field' => $number, 'bucket_size' => 100, 'range' => 'this_month'],
             'p50/p95/p99 of a number' => ['widget' => 'percentiles', 'date_field' => $date, 'field' => $number, 'percents' => '50,95,99', 'range' => 'this_month'],
             'summary of a number' => ['widget' => 'stats', 'date_field' => $date, 'field' => $number, 'range' => 'this_month'],
@@ -171,12 +174,13 @@ class SigmieAnalyticsTool implements Tool
         // `widget` and `date_field` are plain required; every optional param is `nullable()->required()`
         // so the schema stays valid under OpenAI's strict function-calling (callers pass null to omit).
         return [
-            'widget' => $schema->string()->description('kpi | kpi_delta | trend | cumulative | grouped_trend | breakdown | distribution | percentiles | stats | table | funnel | heatmap | retention | geo')->required(),
+            'widget' => $schema->string()->description('kpi | kpi_delta | trend | cumulative | grouped_trend | breakdown | multi_breakdown | distribution | percentiles | stats | table | funnel | heatmap | retention | geo')->required(),
             'date_field' => $schema->string()->description('Timeline (date) field to bucket/scope by')->required(),
             'metric' => $schema->string()->description('sum | avg | min | max | count | unique | median (pass null for distribution, percentiles, stats, table, funnel, retention, geo; optional for heatmap — defaults to count)')->nullable()->required(),
             'field' => $schema->string()->description('Numeric field the metric is computed on; also the numeric field for stats and the geo_point field for the geo widget (pass null for count)')->nullable()->required(),
             'interval' => $schema->string()->description('Time bucket for trends and retention: a calendar unit (minute | hour | day | week | month | quarter | year) or a fixed interval like 15d | 12h | 90m (default day)')->default('day')->nullable()->required(),
             'group_by' => $schema->string()->description('Keyword field to group/break down by, for breakdown and grouped_trend (pass null otherwise)')->nullable()->required(),
+            'group_by_fields' => $schema->string()->description('Comma-separated keyword fields for multi_breakdown, e.g. "product,channel" (pass null otherwise)')->nullable()->required(),
             'limit' => $schema->integer()->description('Max groups for breakdown/grouped_trend, rows for table, or cells per axis for heatmap (default 10)')->default(10)->nullable()->required(),
             'bucket_size' => $schema->integer()->description('Bucket width for the distribution widget (pass null otherwise)')->nullable()->required(),
             'percents' => $schema->string()->description('Comma-separated percentiles for the percentiles widget, e.g. "50,75,95,99" (pass null for the default)')->nullable()->required(),
@@ -269,6 +273,7 @@ class SigmieAnalyticsTool implements Tool
             'cumulative' => $analytics->cumulative('result', $metric(), $field, $interval()),
             'grouped_trend' => $analytics->groupedTrend('result', $metric(), $this->required($request, 'field'), $groupBy(), $interval(), $limit),
             'breakdown' => $analytics->breakdown('result', $groupBy(), $metric(), $field, $limit, bucketAliases: $this->bucketAliases($request)),
+            'multi_breakdown' => $analytics->multiBreakdown('result', $this->groupByFields($request), $metric(), $field, $limit),
             'distribution' => $analytics->distribution('result', $this->required($request, 'field'), (int) ($request['bucket_size'] ?? throw new InvalidArgumentException('The distribution widget requires bucket_size.'))),
             'percentiles' => $analytics->percentiles('result', $this->required($request, 'field'), $this->percents($request)),
             'stats' => $analytics->stats('result', $this->required($request, 'field')),
@@ -277,7 +282,7 @@ class SigmieAnalyticsTool implements Tool
             'heatmap' => $analytics->heatmap('result', $this->required($request, 'row_field'), $this->required($request, 'col_field'), $this->metricOrCount($request), $field, $limit, $limit),
             'retention' => $analytics->retention('result', $this->required($request, 'cohort_field'), $this->required($request, 'id_field'), $interval()),
             'geo' => $analytics->geo('result', $this->required($request, 'field'), max(1, (int) ($request['precision'] ?? 5))),
-            default => throw new InvalidArgumentException(sprintf("Unknown widget '%s'. Use one of: kpi, kpi_delta, trend, cumulative, grouped_trend, breakdown, distribution, percentiles, stats, table, funnel, heatmap, retention, geo.", $widget)),
+            default => throw new InvalidArgumentException(sprintf("Unknown widget '%s'. Use one of: kpi, kpi_delta, trend, cumulative, grouped_trend, breakdown, multi_breakdown, distribution, percentiles, stats, table, funnel, heatmap, retention, geo.", $widget)),
         };
     }
 
@@ -455,6 +460,16 @@ class SigmieAnalyticsTool implements Tool
         }
 
         return $aliases;
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function groupByFields(Request $request): array
+    {
+        $fields = $this->csvList($request, 'group_by_fields');
+
+        return count($fields) >= 2 ? $fields : throw new InvalidArgumentException('The multi_breakdown widget requires at least two group_by_fields.');
     }
 
     protected function configureHits(Analytics $analytics, Request $request): void

--- a/src/Analytics/Analytics.php
+++ b/src/Analytics/Analytics.php
@@ -19,6 +19,7 @@ use Sigmie\Analytics\Widgets\GroupedTrend;
 use Sigmie\Analytics\Widgets\Heatmap;
 use Sigmie\Analytics\Widgets\Kpi;
 use Sigmie\Analytics\Widgets\KpiDelta;
+use Sigmie\Analytics\Widgets\MultiBreakdown;
 use Sigmie\Analytics\Widgets\Percentiles;
 use Sigmie\Analytics\Widgets\Retention;
 use Sigmie\Analytics\Widgets\StatSummary;
@@ -249,6 +250,23 @@ class Analytics implements MultiSearchable
         [$from, $to] = $this->resolveWindow($window);
 
         return $this->addFiltered(new Breakdown($as, $this->dateField, $from, $to, $this->dateFormat, $this->aggregatableField($groupBy), $metric, $this->metricField($metric, $field), $limit, $direction, $bucketAliases), $filter);
+    }
+
+    /**
+     * Add a top-N ranked list over a composite key, such as product + channel by revenue.
+     *
+     * @param  list<string>  $groupBy
+     */
+    public function multiBreakdown(string $as, array $groupBy, Metric $metric, string $field = '', int $limit = 10, string $direction = 'desc', Query|string|null $filter = null, Period|array|null $window = null): static
+    {
+        [$from, $to] = $this->resolveWindow($window);
+
+        $resolvedGroupBy = array_values(array_map(
+            fn (string $field): string => $this->aggregatableField($field),
+            $groupBy,
+        ));
+
+        return $this->addFiltered(new MultiBreakdown($as, $this->dateField, $from, $to, $this->dateFormat, $resolvedGroupBy, $metric, $this->metricField($metric, $field), $limit, $direction), $filter);
     }
 
     public function distribution(string $as, string $field, int $interval, Query|string|null $filter = null, Period|array|null $window = null): static

--- a/src/Analytics/Analytics.php
+++ b/src/Analytics/Analytics.php
@@ -244,11 +244,11 @@ class Analytics implements MultiSearchable
         return $this->addFiltered(new GroupedTrend($as, $this->dateField, $from, $to, $this->dateFormat, $metric, $this->metricField($metric, $field), $this->aggregatableField($groupBy), $interval, $limit, $this->timeZone), $filter);
     }
 
-    public function breakdown(string $as, string $groupBy, Metric $metric, string $field = '', int $limit = 10, string $direction = 'desc', Query|string|null $filter = null, Period|array|null $window = null): static
+    public function breakdown(string $as, string $groupBy, Metric $metric, string $field = '', int $limit = 10, string $direction = 'desc', Query|string|null $filter = null, Period|array|null $window = null, array $bucketAliases = []): static
     {
         [$from, $to] = $this->resolveWindow($window);
 
-        return $this->addFiltered(new Breakdown($as, $this->dateField, $from, $to, $this->dateFormat, $this->aggregatableField($groupBy), $metric, $this->metricField($metric, $field), $limit, $direction), $filter);
+        return $this->addFiltered(new Breakdown($as, $this->dateField, $from, $to, $this->dateFormat, $this->aggregatableField($groupBy), $metric, $this->metricField($metric, $field), $limit, $direction, $bucketAliases), $filter);
     }
 
     public function distribution(string $as, string $field, int $interval, Query|string|null $filter = null, Period|array|null $window = null): static

--- a/src/Analytics/Widgets/Breakdown.php
+++ b/src/Analytics/Widgets/Breakdown.php
@@ -94,6 +94,7 @@ class Breakdown extends Widget
             if ($label === '') {
                 continue;
             }
+
             if ($values === []) {
                 continue;
             }

--- a/src/Analytics/Widgets/Breakdown.php
+++ b/src/Analytics/Widgets/Breakdown.php
@@ -91,8 +91,10 @@ class Breakdown extends Widget
                 static fn (mixed $value): string => trim((string) $value),
                 (array) $values,
             ), static fn (string $value): bool => $value !== ''));
-
-            if ($label === '' || $values === []) {
+            if ($label === '') {
+                continue;
+            }
+            if ($values === []) {
                 continue;
             }
 

--- a/src/Analytics/Widgets/Breakdown.php
+++ b/src/Analytics/Widgets/Breakdown.php
@@ -7,6 +7,7 @@ namespace Sigmie\Analytics\Widgets;
 use DateTimeInterface;
 use Sigmie\Analytics\Enums\Metric;
 use Sigmie\Query\Aggs;
+use Sigmie\Query\Queries\Term\Terms;
 use Sigmie\Shared\Collection;
 
 /**
@@ -26,6 +27,7 @@ class Breakdown extends Widget
         protected string $field,
         protected int $limit,
         protected string $direction,
+        protected array $bucketAliases = [],
     ) {
         parent::__construct($name, $dateField, $from, $to, $dateFormat);
     }
@@ -33,10 +35,21 @@ class Breakdown extends Widget
     public function toRaw(): array
     {
         return $this->scoped($this->name, $this->from, $this->to, function (Aggs $aggs): void {
-            $aggs->terms('groups', $this->groupBy)
+            $terms = $aggs->terms('groups', $this->groupBy)
                 ->size($this->limit)
                 ->order($this->metric->orderKey('metric'), $this->direction)
                 ->aggregate(fn (Aggs $sub) => $this->metric->apply($sub, 'metric', $this->field));
+
+            $excluded = $this->excludedAliasValues();
+
+            if ($excluded !== []) {
+                $terms->exclude($excluded);
+            }
+
+            foreach ($this->normalizedAliases() as $key => $alias) {
+                $aggs->filter($key, new Terms($this->groupBy, $alias['values']))
+                    ->aggregate(fn (Aggs $sub) => $this->metric->apply($sub, 'metric', $this->field));
+            }
         })->toRaw();
     }
 
@@ -44,16 +57,101 @@ class Breakdown extends Widget
     {
         $groups = new Collection($aggregations[$this->name]['groups']['buckets'] ?? []);
 
+        $rows = [
+            ...$groups->map(fn (array $bucket): array => [
+                'key' => $bucket['key'],
+                'value' => $this->metric->extract($bucket['metric'] ?? []),
+                'count' => $bucket['doc_count'] ?? 0,
+            ])->toArray(),
+            ...$this->aliasRows($aggregations),
+        ];
+
+        usort($rows, fn (array $a, array $b): int => $this->compareRows($a, $b));
+
         return [
             'type' => 'breakdown',
             'metric' => $this->metric->value,
             'field' => $this->field,
             'group_by' => $this->groupBy,
-            'rows' => $groups->map(fn (array $bucket): array => [
-                'key' => $bucket['key'],
-                'value' => $this->metric->extract($bucket['metric'] ?? []),
-                'count' => $bucket['doc_count'] ?? 0,
-            ])->toArray(),
+            'rows' => array_slice($rows, 0, $this->limit),
+            ...($this->bucketAliases !== [] ? ['bucket_aliases' => $this->bucketAliases] : []),
         ];
+    }
+
+    /**
+     * @return array<string, array{label: string, values: list<string>}>
+     */
+    protected function normalizedAliases(): array
+    {
+        $aliases = [];
+
+        foreach ($this->bucketAliases as $label => $values) {
+            $label = trim((string) $label);
+            $values = array_values(array_filter(array_map(
+                static fn (mixed $value): string => trim((string) $value),
+                (array) $values,
+            ), static fn (string $value): bool => $value !== ''));
+
+            if ($label === '' || $values === []) {
+                continue;
+            }
+
+            $aliases[$this->aliasAggName($label)] = [
+                'label' => $label,
+                'values' => array_values(array_unique($values)),
+            ];
+        }
+
+        return $aliases;
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function excludedAliasValues(): array
+    {
+        return (new Collection($this->normalizedAliases()))
+            ->flatMap(fn (array $alias): array => $alias['values'])
+            ->unique()
+            ->values();
+    }
+
+    /**
+     * @return list<array{key: string, value: int|float|null, count: int, source_keys: list<string>}>
+     */
+    protected function aliasRows(array $aggregations): array
+    {
+        return (new Collection($this->normalizedAliases()))
+            ->map(function (array $alias, string $key) use ($aggregations): array {
+                $bucket = $aggregations[$this->name][$key] ?? [];
+
+                return [
+                    'key' => $alias['label'],
+                    'value' => $this->metric->extract($bucket['metric'] ?? []),
+                    'count' => $bucket['doc_count'] ?? 0,
+                    'source_keys' => $alias['values'],
+                ];
+            })
+            ->filter(fn (array $row): bool => $row['count'] > 0)
+            ->values();
+    }
+
+    protected function compareRows(array $a, array $b): int
+    {
+        $left = (float) ($a['value'] ?? 0);
+        $right = (float) ($b['value'] ?? 0);
+
+        if ($left === $right) {
+            return ((string) $a['key']) <=> ((string) $b['key']);
+        }
+
+        return $this->direction === 'asc'
+            ? $left <=> $right
+            : $right <=> $left;
+    }
+
+    protected function aliasAggName(string $label): string
+    {
+        return 'alias_'.substr(md5($label), 0, 12);
     }
 }

--- a/src/Analytics/Widgets/MultiBreakdown.php
+++ b/src/Analytics/Widgets/MultiBreakdown.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\Analytics\Widgets;
+
+use DateTimeInterface;
+use Sigmie\Analytics\Enums\Metric;
+use Sigmie\Query\Aggs;
+use Sigmie\Shared\Collection;
+
+class MultiBreakdown extends Widget
+{
+    /**
+     * @param  list<string>  $groupBy
+     */
+    public function __construct(
+        string $name,
+        string $dateField,
+        DateTimeInterface $from,
+        DateTimeInterface $to,
+        string $dateFormat,
+        protected array $groupBy,
+        protected Metric $metric,
+        protected string $field,
+        protected int $limit,
+        protected string $direction,
+    ) {
+        parent::__construct($name, $dateField, $from, $to, $dateFormat);
+    }
+
+    public function toRaw(): array
+    {
+        return $this->scoped($this->name, $this->from, $this->to, function (Aggs $aggs): void {
+            $aggs->multiTerms('groups', $this->groupBy)
+                ->size($this->limit)
+                ->order($this->metric->orderKey('metric'), $this->direction)
+                ->aggregate(fn (Aggs $sub) => $this->metric->apply($sub, 'metric', $this->field));
+        })->toRaw();
+    }
+
+    public function extract(array $aggregations): array
+    {
+        $groups = new Collection($aggregations[$this->name]['groups']['buckets'] ?? []);
+
+        return [
+            'type' => 'multi_breakdown',
+            'metric' => $this->metric->value,
+            'field' => $this->field,
+            'group_by' => $this->groupBy,
+            'rows' => $groups->map(fn (array $bucket): array => $this->row($bucket))->toArray(),
+        ];
+    }
+
+    /**
+     * @return array{key: array<string, mixed>, key_values: list<mixed>, label: string, value: int|float|null, count: int}
+     */
+    protected function row(array $bucket): array
+    {
+        $values = (array) ($bucket['key'] ?? []);
+
+        return [
+            'key' => array_combine($this->groupBy, $values) ?: [],
+            'key_values' => array_values($values),
+            'label' => (string) ($bucket['key_as_string'] ?? implode(' / ', array_map(
+                static fn (mixed $value): string => (string) $value,
+                $values,
+            ))),
+            'value' => $this->metric->extract($bucket['metric'] ?? []),
+            'count' => $bucket['doc_count'] ?? 0,
+        ];
+    }
+}

--- a/src/Query/Aggregations/Bucket/MultiTerms.php
+++ b/src/Query/Aggregations/Bucket/MultiTerms.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\Query\Aggregations\Bucket;
+
+class MultiTerms extends Bucket
+{
+    protected int $size;
+
+    protected array $order = [];
+
+    /**
+     * @param  list<string>  $fields
+     */
+    public function __construct(
+        protected string $name,
+        protected array $fields,
+    ) {}
+
+    public function size(int $size): static
+    {
+        $this->size = $size;
+
+        return $this;
+    }
+
+    public function order(string $subaggregation, string $direction): self
+    {
+        $this->order = ['order' => [
+            $subaggregation => $direction,
+        ]];
+
+        return $this;
+    }
+
+    protected function value(): array
+    {
+        $value = [
+            'multi_terms' => [
+                'terms' => array_map(
+                    fn (string $field): array => ['field' => $field],
+                    $this->fields,
+                ),
+                ...$this->order,
+            ],
+        ];
+
+        if ($this->size ?? false) {
+            $value['multi_terms']['size'] = $this->size;
+        }
+
+        return $value;
+    }
+}

--- a/src/Query/Aggregations/Bucket/Terms.php
+++ b/src/Query/Aggregations/Bucket/Terms.php
@@ -14,6 +14,8 @@ class Terms extends Bucket
 
     protected array $order = [];
 
+    protected array|string|null $exclude = null;
+
     public function __construct(
         protected string $name,
         protected string $field,
@@ -35,6 +37,13 @@ class Terms extends Bucket
         return $this;
     }
 
+    public function exclude(array|string $terms): self
+    {
+        $this->exclude = $terms;
+
+        return $this;
+    }
+
     protected function value(): array
     {
         $value = [
@@ -50,6 +59,10 @@ class Terms extends Bucket
 
         if (isset($this->missing)) {
             $value['terms']['missing'] = $this->missing;
+        }
+
+        if ($this->exclude !== null && $this->exclude !== []) {
+            $value['terms']['exclude'] = $this->exclude;
         }
 
         return $value;

--- a/src/Query/Aggs.php
+++ b/src/Query/Aggs.php
@@ -12,6 +12,7 @@ use Sigmie\Query\Aggregations\Bucket\GeoHashGrid;
 use Sigmie\Query\Aggregations\Bucket\Global_;
 use Sigmie\Query\Aggregations\Bucket\Histogram;
 use Sigmie\Query\Aggregations\Bucket\Missing;
+use Sigmie\Query\Aggregations\Bucket\MultiTerms;
 use Sigmie\Query\Aggregations\Bucket\Nested;
 use Sigmie\Query\Aggregations\Bucket\Range;
 use Sigmie\Query\Aggregations\Bucket\RangeFilter;
@@ -201,6 +202,18 @@ class Aggs implements AggsInterface
     public function terms(string $name, string $field): Terms
     {
         $aggregation = new Terms($name, $field);
+
+        $this->aggs[] = $aggregation;
+
+        return $aggregation;
+    }
+
+    /**
+     * @param  list<string>  $fields
+     */
+    public function multiTerms(string $name, array $fields): MultiTerms
+    {
+        $aggregation = new MultiTerms($name, $fields);
 
         $this->aggs[] = $aggregation;
 

--- a/tests/AnalyticsTest.php
+++ b/tests/AnalyticsTest.php
@@ -45,6 +45,7 @@ class AnalyticsTest extends TestCase
                 $props->date('created_at');
                 $props->number('amount');
                 $props->category('product');
+                $props->category('channel');
 
                 return $props;
             }
@@ -53,11 +54,11 @@ class AnalyticsTest extends TestCase
         $index->create();
 
         $index->merge([
-            new Document(['created_at' => '2024-01-01', 'amount' => 100, 'product' => 'A']),
-            new Document(['created_at' => '2024-01-01', 'amount' => 50, 'product' => 'B']),
-            new Document(['created_at' => '2024-01-02', 'amount' => 200, 'product' => 'A']),
-            new Document(['created_at' => '2024-01-03', 'amount' => 30, 'product' => 'B']),
-            new Document(['created_at' => '2024-01-03', 'amount' => 70, 'product' => 'A']),
+            new Document(['created_at' => '2024-01-01', 'amount' => 100, 'product' => 'A', 'channel' => 'online']),
+            new Document(['created_at' => '2024-01-01', 'amount' => 50, 'product' => 'B', 'channel' => 'online']),
+            new Document(['created_at' => '2024-01-02', 'amount' => 200, 'product' => 'A', 'channel' => 'retail']),
+            new Document(['created_at' => '2024-01-03', 'amount' => 30, 'product' => 'B', 'channel' => 'retail']),
+            new Document(['created_at' => '2024-01-03', 'amount' => 70, 'product' => 'A', 'channel' => 'online']),
         ], refresh: true);
 
         return $index;
@@ -200,6 +201,31 @@ class AnalyticsTest extends TestCase
         $this->assertNotContains('B', array_column($rows, 'key'));
         $this->assertNotContains('C', array_column($rows, 'key'));
         $this->assertNotContains('Old C', array_column($rows, 'key'));
+    }
+
+    /**
+     * @test
+     */
+    public function multi_breakdown_ranks_top_composite_keys_by_metric(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $result = $index->analytics('created_at')
+            ->from($this->date('2024-01-01'))
+            ->to($this->date('2024-01-04'))
+            ->multiBreakdown('top_product_channels', ['product', 'channel'], Metric::Sum, 'amount', limit: 3)
+            ->get();
+
+        $rows = $result['top_product_channels']['rows'];
+
+        $this->assertSame('multi_breakdown', $result['top_product_channels']['type']);
+        $this->assertCount(3, $rows);
+        $this->assertSame(['A', 'retail'], $rows[0]['key_values']);
+        $this->assertEquals(200.0, $rows[0]['value']);
+        $this->assertSame(['A', 'online'], $rows[1]['key_values']);
+        $this->assertEquals(170.0, $rows[1]['value']);
+        $this->assertSame(['B', 'online'], $rows[2]['key_values']);
+        $this->assertEquals(50.0, $rows[2]['value']);
     }
 
     /**

--- a/tests/AnalyticsTest.php
+++ b/tests/AnalyticsTest.php
@@ -171,6 +171,40 @@ class AnalyticsTest extends TestCase
     /**
      * @test
      */
+    public function breakdown_merges_bucket_aliases_in_elasticsearch_before_top_n_ranking(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $index->merge([
+            new Document(['created_at' => '2024-01-02', 'amount' => 250, 'product' => 'B']),
+            new Document(['created_at' => '2024-01-02', 'amount' => 180, 'product' => 'C']),
+            new Document(['created_at' => '2024-01-02', 'amount' => 170, 'product' => 'Old C']),
+        ], refresh: true);
+
+        $result = $index->analytics('created_at')
+            ->from($this->date('2024-01-01'))
+            ->to($this->date('2024-01-04'))
+            ->breakdown('top_products', 'product', Metric::Sum, 'amount', limit: 2, bucketAliases: [
+                'Combined C' => ['C', 'Old C'],
+            ])
+            ->get();
+
+        $rows = $result['top_products']['rows'];
+
+        $this->assertCount(2, $rows);
+        $this->assertSame('A', $rows[0]['key']);
+        $this->assertEquals(370.0, $rows[0]['value']);
+        $this->assertSame('Combined C', $rows[1]['key']);
+        $this->assertEquals(350.0, $rows[1]['value']);
+        $this->assertSame(['C', 'Old C'], $rows[1]['source_keys']);
+        $this->assertNotContains('B', array_column($rows, 'key'));
+        $this->assertNotContains('C', array_column($rows, 'key'));
+        $this->assertNotContains('Old C', array_column($rows, 'key'));
+    }
+
+    /**
+     * @test
+     */
     public function cumulative_runs_a_running_total(): void
     {
         $index = $this->createSalesIndex();

--- a/tests/SigmieAnalyticsToolTest.php
+++ b/tests/SigmieAnalyticsToolTest.php
@@ -94,6 +94,7 @@ class SigmieAnalyticsToolTest extends TestCase
         $this->assertStringContainsString('median', $description);
         $this->assertStringContainsString('include_hits', $description);
         $this->assertStringContainsString('hit_filters', $description);
+        $this->assertStringContainsString('bucket_aliases', $description);
     }
 
     /**
@@ -170,7 +171,7 @@ class SigmieAnalyticsToolTest extends TestCase
         $this->assertFalse($schema['widget']->nullable, "'widget' must NOT be nullable.");
         $this->assertFalse($schema['date_field']->nullable, "'date_field' must NOT be nullable.");
 
-        foreach (['metric', 'field', 'interval', 'group_by', 'limit', 'bucket_size', 'percents', 'from', 'to', 'filters', 'include_hits', 'hit_filters', 'hit_fields', 'hit_sort', 'hit_limit'] as $name) {
+        foreach (['metric', 'field', 'interval', 'group_by', 'limit', 'bucket_size', 'percents', 'from', 'to', 'filters', 'bucket_aliases', 'include_hits', 'hit_filters', 'hit_fields', 'hit_sort', 'hit_limit'] as $name) {
             $this->assertTrue($schema[$name]->nullable, sprintf("Optional property '%s' must be nullable().", $name));
         }
     }
@@ -216,6 +217,37 @@ class SigmieAnalyticsToolTest extends TestCase
 
         $this->assertSame('A', $result['rows'][0]['key']);
         $this->assertEquals(370.0, $result['rows'][0]['value']);
+    }
+
+    /**
+     * @test
+     */
+    public function result_merges_breakdown_bucket_aliases(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $index->merge([
+            new Document(['created_at' => '2024-01-02', 'amount' => 250, 'product' => 'B']),
+            new Document(['created_at' => '2024-01-02', 'amount' => 180, 'product' => 'C']),
+            new Document(['created_at' => '2024-01-02', 'amount' => 170, 'product' => 'Old C']),
+        ], refresh: true);
+
+        $result = (new SigmieAnalyticsTool($index))->result(new Request([
+            'widget' => 'breakdown',
+            'date_field' => 'created_at',
+            'group_by' => 'product',
+            'metric' => 'sum',
+            'field' => 'amount',
+            'limit' => 2,
+            'from' => '2024-01-01',
+            'to' => '2024-01-04',
+            'bucket_aliases' => '[{"label":"Combined C","values":["C","Old C"]}]',
+        ]));
+
+        $this->assertSame('A', $result['rows'][0]['key']);
+        $this->assertSame('Combined C', $result['rows'][1]['key']);
+        $this->assertEquals(350.0, $result['rows'][1]['value']);
+        $this->assertNotContains('B', array_column($result['rows'], 'key'));
     }
 
     /**

--- a/tests/SigmieAnalyticsToolTest.php
+++ b/tests/SigmieAnalyticsToolTest.php
@@ -47,6 +47,7 @@ class SigmieAnalyticsToolTest extends TestCase
                 $props->date('created_at');
                 $props->number('amount');
                 $props->category('product');
+                $props->category('channel');
 
                 return $props;
             }
@@ -55,11 +56,11 @@ class SigmieAnalyticsToolTest extends TestCase
         $index->create();
 
         $index->merge([
-            new Document(['created_at' => '2024-01-01', 'amount' => 100, 'product' => 'A']),
-            new Document(['created_at' => '2024-01-01', 'amount' => 50, 'product' => 'B']),
-            new Document(['created_at' => '2024-01-02', 'amount' => 200, 'product' => 'A']),
-            new Document(['created_at' => '2024-01-03', 'amount' => 30, 'product' => 'B']),
-            new Document(['created_at' => '2024-01-03', 'amount' => 70, 'product' => 'A']),
+            new Document(['created_at' => '2024-01-01', 'amount' => 100, 'product' => 'A', 'channel' => 'online']),
+            new Document(['created_at' => '2024-01-01', 'amount' => 50, 'product' => 'B', 'channel' => 'online']),
+            new Document(['created_at' => '2024-01-02', 'amount' => 200, 'product' => 'A', 'channel' => 'retail']),
+            new Document(['created_at' => '2024-01-03', 'amount' => 30, 'product' => 'B', 'channel' => 'retail']),
+            new Document(['created_at' => '2024-01-03', 'amount' => 70, 'product' => 'A', 'channel' => 'online']),
         ], refresh: true);
 
         return $index;
@@ -95,6 +96,8 @@ class SigmieAnalyticsToolTest extends TestCase
         $this->assertStringContainsString('include_hits', $description);
         $this->assertStringContainsString('hit_filters', $description);
         $this->assertStringContainsString('bucket_aliases', $description);
+        $this->assertStringContainsString('multi_breakdown', $description);
+        $this->assertStringContainsString('group_by_fields', $description);
     }
 
     /**
@@ -143,7 +146,7 @@ class SigmieAnalyticsToolTest extends TestCase
         $this->assertStringContainsString('Examples (', $description);
 
         // One example per widget, as valid JSON grounded in the index's real fields.
-        foreach (['kpi', 'kpi_delta', 'trend', 'cumulative', 'grouped_trend', 'breakdown', 'distribution', 'percentiles', 'stats', 'table', 'funnel', 'heatmap', 'retention', 'geo'] as $widget) {
+        foreach (['kpi', 'kpi_delta', 'trend', 'cumulative', 'grouped_trend', 'breakdown', 'multi_breakdown', 'distribution', 'percentiles', 'stats', 'table', 'funnel', 'heatmap', 'retention', 'geo'] as $widget) {
             $this->assertStringContainsString(sprintf('"widget":"%s"', $widget), $description);
         }
 
@@ -171,7 +174,7 @@ class SigmieAnalyticsToolTest extends TestCase
         $this->assertFalse($schema['widget']->nullable, "'widget' must NOT be nullable.");
         $this->assertFalse($schema['date_field']->nullable, "'date_field' must NOT be nullable.");
 
-        foreach (['metric', 'field', 'interval', 'group_by', 'limit', 'bucket_size', 'percents', 'from', 'to', 'filters', 'bucket_aliases', 'include_hits', 'hit_filters', 'hit_fields', 'hit_sort', 'hit_limit'] as $name) {
+        foreach (['metric', 'field', 'interval', 'group_by', 'group_by_fields', 'limit', 'bucket_size', 'percents', 'from', 'to', 'filters', 'bucket_aliases', 'include_hits', 'hit_filters', 'hit_fields', 'hit_sort', 'hit_limit'] as $name) {
             $this->assertTrue($schema[$name]->nullable, sprintf("Optional property '%s' must be nullable().", $name));
         }
     }
@@ -248,6 +251,31 @@ class SigmieAnalyticsToolTest extends TestCase
         $this->assertSame('Combined C', $result['rows'][1]['key']);
         $this->assertEquals(350.0, $result['rows'][1]['value']);
         $this->assertNotContains('B', array_column($result['rows'], 'key'));
+    }
+
+    /**
+     * @test
+     */
+    public function result_runs_a_multi_breakdown_widget(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $result = (new SigmieAnalyticsTool($index))->result(new Request([
+            'widget' => 'multi_breakdown',
+            'date_field' => 'created_at',
+            'group_by_fields' => 'product,channel',
+            'metric' => 'sum',
+            'field' => 'amount',
+            'limit' => 3,
+            'from' => '2024-01-01',
+            'to' => '2024-01-04',
+        ]));
+
+        $this->assertSame('multi_breakdown', $result['type']);
+        $this->assertSame(['A', 'retail'], $result['rows'][0]['key_values']);
+        $this->assertEquals(200.0, $result['rows'][0]['value']);
+        $this->assertSame(['A', 'online'], $result['rows'][1]['key_values']);
+        $this->assertEquals(170.0, $result['rows'][1]['value']);
     }
 
     /**


### PR DESCRIPTION
## What

Adds analytics support for two ranking problems agents hit often: merging equivalent bucket labels, and ranking combinations of fields.

## Context

Foxy needs to answer requests like "merge Germany and West Germany" without doing fragile post-processing after Elasticsearch has already chosen the top-N buckets. It also needs to answer questions like "top product + channel combinations by revenue" without forcing callers to create a materialized index first.

## Breakdown

- Added bucket aliases for `breakdown`, so exact source labels can be merged into a display bucket before top-N ranking.
- Added `terms.exclude()` support so aliased source labels are removed from the normal terms bucket.
- Exposed `bucket_aliases` through `SigmieAnalyticsTool` for agent/tool callers.
- Added `multi_terms` aggregation support through `Aggs::multiTerms()`.
- Added `Analytics::multiBreakdown()` for ranked composite keys, such as `product + channel` by revenue.
- Exposed agent/tool widget `multi_breakdown` with `group_by_fields`.

## Visuals

Bucket aliases:

```text
User asks: "World Cup titles, merge Germany and West Germany"

Documents in ES
  Germany      -> 1
  West Germany -> 3
  Brazil       -> 5

Analytics breakdown
  alias bucket: Germany = Germany + West Germany
  normal terms: excludes Germany + West Germany

Result shown to caller
  Brazil  5
  Germany 4
  Italy   4
```

Composite-key breakdown:

```text
User asks: "Top product/channel combinations by revenue"

product   channel   revenue
A         online    170
A         retail    200
B         online     50
B         retail     30

multi_breakdown(group_by_fields="product,channel")

Result
A / retail  200
A / online  170
B / online   50
```

Tool choice:

```text
Single dimension ranking
  "top countries by titles"
        -> breakdown(group_by="country")

Explicit label merge
  "merge Germany and West Germany"
        -> breakdown(..., bucket_aliases=[...])

Combination ranking
  "top product + channel combinations"
        -> multi_breakdown(group_by_fields="product,channel")
```

## Validation

- `./vendor/bin/phpunit tests/AnalyticsTest.php`
- `./vendor/bin/phpunit tests/SigmieAnalyticsToolTest.php`

Both suites hit the configured local Elasticsearch instance. Tests verify alias merging before top-N ranking and real `multi_terms` composite-key ranking through both the PHP analytics API and the agent-facing tool.
