### PR TITLE
Support custom count metric sorting

### DIFF
--- a/src/Analytics/Analytics.php
+++ b/src/Analytics/Analytics.php
@@ -301,10 +301,34 @@ class Analytics implements MultiSearchable
             'metric' => Metric::Count,
             'field' => '',
         ]];
-        $metricKeys = array_column($resolvedMetrics, 'key');
-        $sortMetric = in_array($sortMetric, $metricKeys, true) ? $sortMetric : (string) ($metricKeys[0] ?? 'count');
+        $sortMetric = $this->groupedMetricsSortMetric($resolvedMetrics, $sortMetric);
 
         return $this->addFiltered(new GroupedMetrics($as, $this->dateField, $from, $to, $this->dateFormat, $this->aggregatableField($groupBy), $resolvedMetrics, $sortMetric, $limit, $direction, $minCount), $filter);
+    }
+
+    /**
+     * @param  list<array{key: string, label: string, metric: Metric, field: string}>  $metrics
+     */
+    protected function groupedMetricsSortMetric(array $metrics, string $sortMetric): string
+    {
+        $metricKeys = array_column($metrics, 'key');
+
+        if (in_array($sortMetric, $metricKeys, true)) {
+            return $sortMetric;
+        }
+
+        if ($sortMetric === 'count') {
+            $countMetric = array_values(array_filter(
+                $metrics,
+                fn (array $metric): bool => $metric['metric'] === Metric::Count,
+            ))[0] ?? null;
+
+            if (is_array($countMetric)) {
+                return $countMetric['key'];
+            }
+        }
+
+        return (string) ($metricKeys[0] ?? 'count');
     }
 
     /**

--- a/src/Analytics/Widgets/GroupedMetrics.php
+++ b/src/Analytics/Widgets/GroupedMetrics.php
@@ -116,6 +116,10 @@ class GroupedMetrics extends Widget
             return '_count';
         }
 
+        if ($metric['metric'] === Metric::Count) {
+            return '_count';
+        }
+
         return $metric['metric']->orderKey($metric['key']);
     }
 }

--- a/tests/AnalyticsTest.php
+++ b/tests/AnalyticsTest.php
@@ -325,6 +325,56 @@ class AnalyticsTest extends TestCase
     /**
      * @test
      */
+    public function grouped_metrics_sorts_count_metrics_with_domain_specific_keys(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $result = $index->analytics('created_at')
+            ->from($this->date('2024-01-01'))
+            ->to($this->date('2024-01-04'))
+            ->groupedMetrics('product_metrics', 'product', [
+                ['key' => 'orders', 'label' => 'Orders', 'metric' => Metric::Count],
+                ['key' => 'avg_amount', 'label' => 'Average amount', 'metric' => Metric::Avg, 'field' => 'amount'],
+            ], sortMetric: 'orders', minCount: 2)
+            ->get();
+
+        $rows = $result['product_metrics']['rows'];
+
+        $this->assertSame('orders', $result['product_metrics']['sort_metric']);
+        $this->assertSame('A', $rows[0]['key']);
+        $this->assertEquals(3, $rows[0]['metrics']['orders']);
+        $this->assertSame('B', $rows[1]['key']);
+        $this->assertEquals(2, $rows[1]['metrics']['orders']);
+    }
+
+    /**
+     * @test
+     */
+    public function grouped_metrics_sort_metric_count_uses_the_count_metric_even_when_it_has_a_custom_key(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $result = $index->analytics('created_at')
+            ->from($this->date('2024-01-01'))
+            ->to($this->date('2024-01-04'))
+            ->groupedMetrics('product_metrics', 'product', [
+                ['key' => 'avg_amount', 'label' => 'Average amount', 'metric' => Metric::Avg, 'field' => 'amount'],
+                ['key' => 'orders', 'label' => 'Orders', 'metric' => Metric::Count],
+            ], sortMetric: 'count', minCount: 2)
+            ->get();
+
+        $rows = $result['product_metrics']['rows'];
+
+        $this->assertSame('orders', $result['product_metrics']['sort_metric']);
+        $this->assertSame('A', $rows[0]['key']);
+        $this->assertEquals(3, $rows[0]['metrics']['orders']);
+        $this->assertSame('B', $rows[1]['key']);
+        $this->assertEquals(2, $rows[1]['metrics']['orders']);
+    }
+
+    /**
+     * @test
+     */
     public function grouped_metrics_applies_min_count_before_returning_groups(): void
     {
         $index = $this->createSalesIndex();


### PR DESCRIPTION
## Summary

This PR makes `grouped_metrics` own count-metric sorting correctly inside `sigmie/sigmie`.

Before this change, `grouped_metrics` only sorted count-based rankings safely when the count metric key was literally `count`. If a caller used a domain-specific metric key such as `orders`, `recipes`, `sessions`, `customers`, or `products`, the analytics widget could build an Elasticsearch terms aggregation ordered by that custom key. Count metrics do not create a sub-aggregation under that key, because they are represented by the bucket `doc_count`. That means Elasticsearch can reject the query with an error like:

```text
No aggregation found for path [recipes]
```

This is library behavior, so consumers should not need to patch or normalize it in their own application adapters.

## What changed

- `Analytics::groupedMetrics()` now resolves `sortMetric: 'count'` to the first count metric in the metric list, even when that metric has a domain-specific key.
- `GroupedMetrics::sortOrderKey()` now orders any `Metric::Count` metric through Elasticsearch `_count`, not through the metric key.
- Added regression coverage for both supported forms:
  - Sorting by a custom count metric key, for example `sortMetric: 'orders'`.
  - Sorting by the generic shorthand `sortMetric: 'count'` when the actual count metric key is custom, for example `orders`.

## How to use it

Use `groupedMetrics()` when you need one row per group and each row should carry multiple metrics. This is the correct analytics shape for leaderboards and ranked breakdowns where the ranking metric is not the only value displayed.

Example: rank products by order count while also showing average order amount.

```php
$result = $index->analytics('created_at')
    ->from(new DateTimeImmutable('2024-01-01'))
    ->to(new DateTimeImmutable('2024-02-01'))
    ->groupedMetrics('product_metrics', 'product', [
        ['key' => 'orders', 'label' => 'Orders', 'metric' => Metric::Count],
        ['key' => 'avg_amount', 'label' => 'Average amount', 'metric' => Metric::Avg, 'field' => 'amount'],
    ], sortMetric: 'orders', minCount: 5)
    ->get();
```

The same request can also use the generic count shorthand:

```php
$result = $index->analytics('created_at')
    ->from(new DateTimeImmutable('2024-01-01'))
    ->to(new DateTimeImmutable('2024-02-01'))
    ->groupedMetrics('product_metrics', 'product', [
        ['key' => 'orders', 'label' => 'Orders', 'metric' => Metric::Count],
        ['key' => 'avg_amount', 'label' => 'Average amount', 'metric' => Metric::Avg, 'field' => 'amount'],
    ], sortMetric: 'count', minCount: 5)
    ->get();
```

Both forms now sort by bucket document count internally while preserving the caller's metric key in the result payload.

## Tool/API usage

For `SigmieAnalyticsTool`, callers can now safely pass domain-specific count metric keys in grouped metrics payloads:

```json
{
  "widget": "grouped_metrics",
  "date_field": "created_at",
  "group_by": "author",
  "metrics": "[{\"key\":\"recipes\",\"label\":\"Recipes\",\"metric\":\"count\"},{\"key\":\"avg_rating\",\"label\":\"Average rating\",\"metric\":\"avg\",\"field\":\"rating\"}]",
  "sort_metric": "recipes",
  "min_count": 5,
  "limit": 10
}
```

This also supports:

```json
"sort_metric": "count"
```

when the metric list contains a count metric with a custom key.

## Chart and analytics shapes this supports

This does not introduce a new chart type. It makes the existing `grouped_metrics` result shape reliable for the chart renderers and agent tools that already consume Sigmie analytics results.

The fixed shape is useful for:

- Top authors by recipe count, carrying average rating.
- Top products by order count, carrying revenue or average order value.
- Top customers, countries, categories, campaigns, or channels by count, carrying secondary metrics.
- Leaderboards with a minimum group size, via `minCount` / `min_count`.
- Bar charts where the bar value is count but the tooltip/table also shows additional metrics.
- Table views where each row is a group and each metric is a column.

More broadly, this keeps `grouped_metrics` aligned with the rest of the analytics widget family:

- `kpi` and `kpi_delta` for single-number metrics.
- `trend`, `cumulative`, and `grouped_trend` for time-series charts.
- `breakdown` for one metric by one dimension.
- `distribution` for numeric histograms.
- `histogram_metric` for a metric aggregated inside numeric buckets, such as average rating by calorie bucket.
- `grouped_metrics` for ranked groups carrying more than one metric.
- `percentiles` and `stats` for spread and summary cards.
- `table` for source rows.
- `funnel`, `heatmap`, `retention`, and `geo` for their specialized chart contracts.

## Why this belongs in Sigmie

The distinction between a metric key and Elasticsearch's `_count` ordering is part of the analytics engine contract. Applications and agents should be able to describe the business metric using natural keys like `recipes`, `orders`, or `customers` without knowing how Elasticsearch represents document counts inside terms buckets.

Keeping this logic in `sigmie/sigmie` means consumers can use the same grouped metric contract across PHP calls, AI tools, MCP tools, and UI renderers without app-specific normalization.

## Verification

- `php -l src/Analytics/Analytics.php`
- `php -l src/Analytics/Widgets/GroupedMetrics.php`
- `php -l tests/AnalyticsTest.php`

PHPUnit was not run because this repository's agent guide says not to run tests unless explicitly requested.
