### PR TITLE
[codex] Add API key host connection factory

### DIFF
--- a/docs/connection.md
+++ b/docs/connection.md
@@ -56,6 +56,19 @@ curl -X POST "localhost:9200/_security/api_key" \
   -d '{"name": "my-api-key", "expiration": "90d"}'
 ```
 
+Use `createWithApiKey()` when the cluster exposes a normal Elasticsearch endpoint, including hosted Elastic Cloud deployments where you already have the endpoint URL:
+
+```php
+use Sigmie\Sigmie;
+
+$sigmie = Sigmie::createWithApiKey(
+    hosts: ['https://my-deployment.es.us-east-1.aws.elastic.cloud'],
+    apiKey: 'your-api-key'
+);
+```
+
+This connection is not marked as serverless, so index settings like `number_of_replicas` are still sent when you create indices.
+
 Base64-encode `id:api_key` and pass it as the Authorization header:
 
 ```php

--- a/src/Sigmie.php
+++ b/src/Sigmie.php
@@ -260,6 +260,26 @@ class Sigmie
         return new static(new HttpConnection($client, new Elasticsearch, serverless: true));
     }
 
+    public static function createWithApiKey(
+        array|string $hosts,
+        string $apiKey,
+        SearchEngineType $engine = SearchEngineType::Elasticsearch,
+        array $config = []
+    ): static {
+        $hosts = is_string($hosts) ? explode(',', $hosts) : $hosts;
+
+        $client = JSONClient::createWithHeaders($hosts, [
+            'Authorization' => 'ApiKey '.$apiKey,
+        ], $config);
+
+        $driver = match ($engine) {
+            SearchEngineType::Elasticsearch => new Elasticsearch,
+            SearchEngineType::OpenSearch => new Opensearch,
+        };
+
+        return new static(new HttpConnection($client, $driver));
+    }
+
     public static function create(
         array|string $hosts,
         SearchEngineType $engine = SearchEngineType::Elasticsearch,

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -48,6 +48,20 @@ class HttpTest extends TestCase
     /**
      * @test
      */
+    public function create_with_api_key_returns_non_serverless_sigmie_instance(): void
+    {
+        $sigmie = Sigmie::createWithApiKey(
+            'https://my-deployment.es.us-east-1.aws.elastic.cloud',
+            'my-api-key'
+        );
+
+        $this->assertInstanceOf(Sigmie::class, $sigmie);
+        $this->assertFalse($sigmie->isServerless());
+    }
+
+    /**
+     * @test
+     */
     public function response(): void
     {
         $successfulResponse = JSONResponse::fromPsrResponse(new PsrResponse(200, ['content-type' => 'application/json'], '{"foo":"bar"}'));

--- a/tests/IndexBuilderTest.php
+++ b/tests/IndexBuilderTest.php
@@ -30,6 +30,7 @@ use Sigmie\Languages\German\German;
 use Sigmie\Languages\Greek\Builder as GreekBuilder;
 use Sigmie\Languages\Greek\Greek;
 use Sigmie\Mappings\NewProperties;
+use Sigmie\Sigmie;
 use Sigmie\Testing\Assert;
 use Sigmie\Testing\TestCase;
 
@@ -1144,6 +1145,27 @@ class IndexBuilderTest extends TestCase
         $raw = $settings->toRaw();
         $this->assertArrayNotHasKey('number_of_shards', $raw);
         $this->assertArrayNotHasKey('number_of_replicas', $raw);
+    }
+
+    /**
+     * @test
+     */
+    public function api_key_connection_keeps_index_shard_replica_settings(): void
+    {
+        $sigmie = Sigmie::createWithApiKey(
+            'https://my-deployment.es.us-east-1.aws.elastic.cloud',
+            'my-api-key'
+        );
+
+        $settings = $sigmie->newIndex(uniqid())
+            ->shards(1)
+            ->replicas(0)
+            ->make()
+            ->settings
+            ->toRaw();
+
+        $this->assertSame(1, $settings['number_of_shards']);
+        $this->assertSame(0, $settings['number_of_replicas']);
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds `Sigmie::createWithApiKey()` for Elasticsearch endpoints that use API key authentication but should not be treated as serverless.

## Why

Hosted Elastic Cloud deployments can be reached with a direct Elasticsearch endpoint plus API key. Before this change, callers using that connection shape often reached for `createForServerless()`, which also marks the connection as serverless. That causes index creation to omit shard and replica settings, including `number_of_replicas`.

This PR separates the connection method from serverless index behavior:

- `createWithApiKey()` uses host(s) + `ApiKey ...` auth and keeps normal Elasticsearch index settings.
- `createForServerless()` remains the explicit serverless factory and still omits shard/replica settings.

## Validation

- `php -l src/Sigmie.php`
- `php -l tests/HttpTest.php`
- `php -l tests/IndexBuilderTest.php`

I did not run the test suite because the repository instructions say not to run tests unless asked.
