### PR TITLE
Require Codecov token uploads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,9 +163,11 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           flags: elasticsearch
           name: elasticsearch-${{ matrix.elasticsearch_version }}
+          fail_ci_if_error: true
 
   test-opensearch:
     needs: code-quality
@@ -287,6 +289,8 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           flags: opensearch
           name: opensearch-${{ matrix.opensearch_version }}
+          fail_ci_if_error: true


### PR DESCRIPTION
## Summary
- Pass the `CODECOV_TOKEN` secret to both Codecov upload steps.
- Enable `fail_ci_if_error` so upload failures fail the workflow instead of leaving stale coverage on Codecov.

## Why
The merged coverage PR generated `coverage.xml`, but Codecov rejected both uploads with a 429 because the uploader ran without the repository token. The action still exited successfully, so GitHub showed green while Codecov stayed on the previous 70% report.

## Validation
- Inspected the workflow diff.
- No tests run; this is a workflow-only change.
