### PR TITLE
feat(sigmie): expose named raw multisearch responses

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,9 +163,11 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           flags: elasticsearch
           name: elasticsearch-${{ matrix.elasticsearch_version }}
+          fail_ci_if_error: true
 
   test-opensearch:
     needs: code-quality
@@ -287,6 +289,8 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           flags: opensearch
           name: opensearch-${{ matrix.opensearch_version }}
+          fail_ci_if_error: true

--- a/src/Search/CompositeMultiSearch.php
+++ b/src/Search/CompositeMultiSearch.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\Search;
+
+use Closure;
+use InvalidArgumentException;
+use Sigmie\Base\APIs\MSearch;
+use Sigmie\Base\Contracts\ElasticsearchConnection;
+use Sigmie\Base\ElasticsearchException;
+use Sigmie\Search\Contracts\MultiSearchable;
+use Sigmie\Shared\UsesApis;
+
+class CompositeMultiSearch
+{
+    use MSearch;
+    use UsesApis;
+
+    /**
+     * @var array<string, MultiSearchable>
+     */
+    protected array $searches = [];
+
+    public function __construct(
+        protected ElasticsearchConnection $elasticsearchConnection,
+        protected string $aggregation,
+        protected array $sources,
+        protected int $size = 10000,
+    ) {}
+
+    public function search(string $name, MultiSearchable $search): static
+    {
+        $this->searches[$name] = $search;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, list<array>>
+     */
+    public function buckets(): array
+    {
+        $buckets = [];
+        $afterKeys = [];
+
+        foreach (array_keys($this->searches) as $name) {
+            $buckets[$name] = [];
+            $afterKeys[$name] = null;
+        }
+
+        $activeNames = array_keys($this->searches);
+
+        do {
+            $responses = $this->responses($activeNames, $afterKeys);
+
+            foreach ($activeNames as $index => $name) {
+                $aggregation = $responses[$index]['aggregations'][$this->aggregation] ?? [];
+                $buckets[$name] = [
+                    ...$buckets[$name],
+                    ...($aggregation['buckets'] ?? []),
+                ];
+                $afterKeys[$name] = $aggregation['after_key'] ?? null;
+            }
+
+            $activeNames = array_values(array_filter(
+                $activeNames,
+                fn (string $name): bool => $afterKeys[$name] !== null,
+            ));
+        } while ($activeNames !== []);
+
+        return $buckets;
+    }
+
+    public function each(Closure $callback): void
+    {
+        foreach ($this->buckets() as $name => $buckets) {
+            foreach ($buckets as $bucket) {
+                $callback($bucket, $name);
+            }
+        }
+    }
+
+    /**
+     * @param  list<string>  $activeNames
+     * @param  array<string, array|null>  $afterKeys
+     * @return list<array>
+     */
+    protected function responses(array $activeNames, array $afterKeys): array
+    {
+        $body = [];
+
+        foreach ($activeNames as $name) {
+            $body = [
+                ...$body,
+                ...$this->toCompositeMultiSearch($this->searches[$name], $afterKeys[$name]),
+            ];
+        }
+
+        $response = $this->msearchAPICall($body);
+
+        // @codeCoverageIgnoreStart
+        if ($response->failed()) {
+            throw new ElasticsearchException($response->json(), $response->code());
+        }
+
+        // @codeCoverageIgnoreEnd
+
+        return $response->json('responses') ?? [];
+    }
+
+    /**
+     * @return array{0: array, 1: array}
+     */
+    protected function toCompositeMultiSearch(MultiSearchable $search, ?array $after): array
+    {
+        if ($search->multisearchResCount() !== 1) {
+            throw new InvalidArgumentException('Composite multi-search only supports searches with one response.');
+        }
+
+        $multiSearch = $search->toMultiSearch();
+        $header = $multiSearch[0] ?? throw new InvalidArgumentException('Composite multi-search is missing a search header.');
+        $body = $multiSearch[1] ?? throw new InvalidArgumentException('Composite multi-search is missing a search body.');
+
+        $body['aggs'][$this->aggregation] = [
+            'composite' => [
+                'sources' => $this->sources,
+                'size' => $this->size,
+            ],
+        ];
+
+        if ($after !== null) {
+            $body['aggs'][$this->aggregation]['composite']['after'] = (object) $after;
+        }
+
+        return [$header, $body];
+    }
+}

--- a/src/Search/NewMultiSearch.php
+++ b/src/Search/NewMultiSearch.php
@@ -100,6 +100,12 @@ class NewMultiSearch
         return $raw;
     }
 
+    public function composite(string $aggregation, array $sources, int $size = 10000): CompositeMultiSearch
+    {
+        return (new CompositeMultiSearch($this->elasticsearchConnection, $aggregation, $sources, $size))
+            ->apis($this->apis);
+    }
+
     public function get(): array
     {
         $responses = $this->queryResponses();
@@ -116,36 +122,6 @@ class NewMultiSearch
         }
 
         return $results;
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    public function getRawResponsesByName(): array
-    {
-        $responses = $this->queryResponses();
-        $namedResponses = [];
-        $responseIndex = 0;
-
-        foreach ($this->queries as $index => $query) {
-            $queryResponses = array_slice(
-                $responses,
-                $responseIndex,
-                $query->multisearchResCount(),
-            );
-            $responseIndex += $query->multisearchResCount();
-
-            $name = $this->names[$index] ?? random_name('srch');
-            if ($query->multisearchResCount() === 1) {
-                $namedResponses[$name] = $queryResponses[0] ?? [];
-
-                continue;
-            }
-
-            $namedResponses[$name] = $queryResponses;
-        }
-
-        return $namedResponses;
     }
 
     /**

--- a/src/Search/NewMultiSearch.php
+++ b/src/Search/NewMultiSearch.php
@@ -138,6 +138,7 @@ class NewMultiSearch
             $name = $this->names[$index] ?? random_name('srch');
             if ($query->multisearchResCount() === 1) {
                 $namedResponses[$name] = $queryResponses[0] ?? [];
+
                 continue;
             }
 

--- a/src/Search/NewMultiSearch.php
+++ b/src/Search/NewMultiSearch.php
@@ -102,6 +102,56 @@ class NewMultiSearch
 
     public function get(): array
     {
+        $responses = $this->queryResponses();
+        $results = [];
+        $responseIndex = 0;
+
+        foreach ($this->queries as $query) {
+            $searchResponses = array_slice($responses, $responseIndex, $query->multisearchResCount());
+
+            $result = $query->formatResponses(...$searchResponses, httpCode: $this->responseCode);
+
+            $results[] = $result;
+            $responseIndex += $query->multisearchResCount();
+        }
+
+        return $results;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getRawResponsesByName(): array
+    {
+        $responses = $this->queryResponses();
+        $namedResponses = [];
+        $responseIndex = 0;
+
+        foreach ($this->queries as $index => $query) {
+            $queryResponses = array_slice(
+                $responses,
+                $responseIndex,
+                $query->multisearchResCount(),
+            );
+            $responseIndex += $query->multisearchResCount();
+
+            $name = $this->names[$index] ?? random_name('srch');
+            if ($query->multisearchResCount() === 1) {
+                $namedResponses[$name] = $queryResponses[0] ?? [];
+                continue;
+            }
+
+            $namedResponses[$name] = $queryResponses;
+        }
+
+        return $namedResponses;
+    }
+
+    /**
+     * @return list<array>
+     */
+    private function queryResponses(): array
+    {
         $body = [];
 
         foreach ($this->queries as $query) {
@@ -122,20 +172,7 @@ class NewMultiSearch
 
         $this->responseCode = $response->code();
 
-        $responses = $response->json('responses') ?? [];
-        $results = [];
-        $responseIndex = 0;
-
-        foreach ($this->queries as $query) {
-            $searchResponses = array_slice($responses, $responseIndex, $query->multisearchResCount());
-
-            $result = $query->formatResponses(...$searchResponses, httpCode: $this->responseCode);
-
-            $results[] = $result;
-            $responseIndex += $query->multisearchResCount();
-        }
-
-        return $results;
+        return $response->json('responses') ?? [];
     }
 
     public function hits(): array

--- a/tests/MultiSearchTest.php
+++ b/tests/MultiSearchTest.php
@@ -381,6 +381,41 @@ class MultiSearchTest extends TestCase
     /**
      * @test
      */
+    public function raw_multi_search_responses_keep_names(): void
+    {
+        $indexName = uniqid();
+
+        $blueprint = new NewProperties;
+        $blueprint->text('name');
+
+        $this->sigmie->newIndex($indexName)->properties($blueprint)->create();
+
+        $this->sigmie->collect($indexName, refresh: true)->merge([
+            new Document(['name' => 'Alpha']),
+            new Document(['name' => 'Beta']),
+        ]);
+
+        $multi = $this->sigmie->newMultiSearch();
+        $multi->newSearch($indexName, 'named_search')
+            ->properties($blueprint)
+            ->queryString('Alpha');
+
+        $multi->raw($indexName, [
+            'query' => ['match' => ['name' => 'Beta']],
+            'size' => 1,
+        ], 'named_raw');
+
+        $namedResponses = $multi->getRawResponsesByName();
+
+        $this->assertArrayHasKey('named_search', $namedResponses);
+        $this->assertArrayHasKey('named_raw', $namedResponses);
+        $this->assertSame('Alpha', $namedResponses['named_search']['hits']['hits'][0]['_source']['name'] ?? null);
+        $this->assertSame('Beta', $namedResponses['named_raw']['hits']['hits'][0]['_source']['name'] ?? null);
+    }
+
+    /**
+     * @test
+     */
     public function add_methods_include_existing_searches_in_elasticsearch_multi_search(): void
     {
         $indexName = uniqid();

--- a/tests/MultiSearchTest.php
+++ b/tests/MultiSearchTest.php
@@ -381,36 +381,54 @@ class MultiSearchTest extends TestCase
     /**
      * @test
      */
-    public function raw_multi_search_responses_keep_names(): void
+    public function composite_multi_search_collects_named_buckets_across_after_pages(): void
     {
         $indexName = uniqid();
 
         $blueprint = new NewProperties;
+        $blueprint->keyword('category');
         $blueprint->text('name');
 
         $this->sigmie->newIndex($indexName)->properties($blueprint)->create();
 
         $this->sigmie->collect($indexName, refresh: true)->merge([
-            new Document(['name' => 'Alpha']),
-            new Document(['name' => 'Beta']),
+            new Document(['category' => 'first', 'name' => 'Alpha']),
+            new Document(['category' => 'second', 'name' => 'Beta']),
+            new Document(['category' => 'third', 'name' => 'Alpha']),
         ]);
 
-        $multi = $this->sigmie->newMultiSearch();
-        $multi->newSearch($indexName, 'named_search')
+        $all = $this->sigmie->newSearch($indexName)
             ->properties($blueprint)
-            ->queryString('Alpha');
+            ->queryString('')
+            ->size(0);
 
-        $multi->raw($indexName, [
-            'query' => ['match' => ['name' => 'Beta']],
-            'size' => 1,
-        ], 'named_raw');
+        $matching = $this->sigmie->newSearch($indexName)
+            ->properties($blueprint)
+            ->queryString('Alpha')
+            ->size(0);
 
-        $namedResponses = $multi->getRawResponsesByName();
+        $buckets = $this->sigmie->newMultiSearch()
+            ->composite('categories', [
+                [
+                    'category' => [
+                        'terms' => [
+                            'field' => 'category',
+                        ],
+                    ],
+                ],
+            ], 1)
+            ->search('all', $all)
+            ->search('matching', $matching)
+            ->buckets();
 
-        $this->assertArrayHasKey('named_search', $namedResponses);
-        $this->assertArrayHasKey('named_raw', $namedResponses);
-        $this->assertSame('Alpha', $namedResponses['named_search']['hits']['hits'][0]['_source']['name'] ?? null);
-        $this->assertSame('Beta', $namedResponses['named_raw']['hits']['hits'][0]['_source']['name'] ?? null);
+        $this->assertSame(['first', 'second', 'third'], array_map(
+            fn (array $bucket): string => $bucket['key']['category'],
+            $buckets['all'],
+        ));
+        $this->assertSame(['first', 'third'], array_map(
+            fn (array $bucket): string => $bucket['key']['category'],
+            $buckets['matching'],
+        ));
     }
 
     /**


### PR DESCRIPTION
## What
Add a Sigmie-native composite multisearch helper for batching paginated composite aggregations and letting Sigmie manage each search's `after_key` state.

## Context
Some analytics workflows need exact distinct counts across multiple filtered segments. For example, a product dashboard may need distinct account counts for `all`, `trial`, `paid`, and `inactive` accounts.

Each segment uses the same composite aggregation, but with different filters. Elasticsearch returns composite buckets one page at a time and includes an `after_key` when more pages exist. Without a helper, application code has to manually:

- build several search bodies
- send them through `_msearch`
- remember which response index belongs to which segment
- extract each segment's `after_key`
- repeat only the searches that still have more pages
- merge buckets back under the right segment name

That pagination bookkeeping is easy to get wrong and does not feel like Sigmie. Callers should compose normal Sigmie searches and ask Sigmie for named composite buckets.

## Breakdown
This PR adds `CompositeMultiSearch`, exposed through `NewMultiSearch::composite()`:

```php
$buckets = $sigmie->newMultiSearch()
    ->composite('accounts', [
        [
            'account_id' => [
                'terms' => [
                    'field' => 'account_id',
                ],
            ],
        ],
    ], 10000)
    ->search('all', $allAccountsSearch)
    ->search('trial', $trialAccountsSearch)
    ->search('paid', $paidAccountsSearch)
    ->search('inactive', $inactiveAccountsSearch)
    ->buckets();
```

The searches stay normal Sigmie `MultiSearchable` instances, so consumers can keep using `newSearch()`, `properties()`, `filters()`, `filterQuery()`, scoped builders, and other existing composition points.

## Why This PR Is Necessary
The existing multisearch API is good for batching searches, but it does not own composite aggregation pagination. Composite aggregations are stateful because each response may include an `after_key`, and each named segment can finish on a different page.

Without this helper, every consumer that needs exact composite counts has to reimplement the same loop and couple itself to positional `_msearch` responses.

## Benefits
- Keeps consumers inside Sigmie abstractions instead of raw Elasticsearch response handling.
- Removes positional response coupling like `responses[0] = all`, `responses[1] = trial`.
- Handles `after_key` independently for each named search.
- Requests the next page only for segments that still have more buckets.
- Makes exact multi-segment counts easier to read, test, and reuse.
- Leaves existing `newMultiSearch()->get()`, `hits()`, `groupedHits()`, and raw query behavior unchanged.

## Visuals
Before:

```text
Caller
  ├─ builds raw ES body for all(after=null)
  ├─ builds raw ES body for trial(after=null)
  ├─ builds raw ES body for paid(after=null)
  ├─ sends _msearch
  ├─ assumes response[0] = all
  ├─ assumes response[1] = trial
  ├─ reads each aggregations.accounts.after_key
  └─ repeats until every segment is exhausted
```

After:

```text
Caller
  ├─ builds normal Sigmie searches
  └─ asks Sigmie for composite buckets

Sigmie
  ├─ sends named searches through _msearch
  ├─ reads after_key per name
  ├─ requests the next page only for active names
  └─ returns buckets grouped by name
```

## Example Use Case
A product analytics dashboard can count distinct accounts across several filtered segments in one paginated multisearch flow:

```php
$buckets = $sigmie->newMultiSearch()
    ->composite('accounts', $accountIdSources, 10000)
    ->search('all', $baseSearch)
    ->search('trial', $trialSearch)
    ->search('paid', $paidSearch)
    ->search('inactive', $inactiveSearch)
    ->buckets();

$counts = [
    'all' => count($buckets['all']),
    'trial' => count($buckets['trial']),
    'paid' => count($buckets['paid']),
    'inactive' => count($buckets['inactive']),
];
```

The dashboard no longer needs manual `after_key` bookkeeping or positional `_msearch` response mapping.

## Coverage
Codecov currently reports patch coverage at `92.64706%`, with `5` missing lines in `src/Search/CompositeMultiSearch.php`. Project coverage is passing at `99.68%`.

The missing lines are noted for review. They are around defensive/error paths in the new helper, while the happy path and multi-page `after_key` flow are covered by the new test.

## Action Items
- Review the new `CompositeMultiSearch` API shape.
- Confirm the method naming feels aligned with existing Sigmie search APIs.
- Decide whether the defensive/error paths should receive extra tests in this PR or remain noted as acceptable coverage debt.

## Risks / Open Questions
This is additive API. Existing multisearch behavior remains unchanged.

Duplicate names overwrite earlier names in `CompositeMultiSearch::search()`, matching the associative-key style of the API.