### PR TITLE
Add union breakdown analytics

### DIFF
--- a/docs/aggregations.md
+++ b/docs/aggregations.md
@@ -1,7 +1,7 @@
 ---
 title: Aggregations
 short_description: Run Elasticsearch metric and bucket aggregations with Sigmie — sum, avg, stats, terms, histogram, date histogram, geohash grid, and pipeline aggregations.
-keywords: [aggregations, facets, analytics, bucket aggregations, metrics]
+keywords: [aggregations, facets, analytics, bucket aggregations, union terms, metrics]
 category: Features
 order: 2
 related_pages: [facets, search]
@@ -109,6 +109,28 @@ $response->aggregation('category_terms.buckets');
 ```
 
 `missing('N/A')` puts documents without the field into a bucket of that key.
+
+### Union terms
+
+`unionTerms()` combines the same label from several role fields into one terms bucket. This is useful when one logical dimension is stored in fields such as `champion_country` and `runner_up_country`:
+
+```php
+use Sigmie\Query\Aggs;
+use Sigmie\Query\Aggregations\Metrics\Sum;
+
+$agg->unionTerms('countries', ['champion_country', 'runner_up_country'])
+    ->size(10)
+    ->order('prize_total', 'desc')
+    ->aggregate(fn (Aggs $sub): Sum => $sub->sum('prize_total', 'prize'));
+
+$response->aggregation('countries.buckets');
+// [
+//     ['key' => 'Germany', 'doc_count' => 4, 'prize_total' => ['value' => 420.0]],
+//     ...
+// ]
+```
+
+Field names are passed to a fixed aggregation script as parameters. A document that contains the same label in multiple configured fields contributes to that label once. Use the higher-level [`unionBreakdown()`](analytics.md#union-breakdown) API when you also want mapping validation, time windows, filters, and normalized rows.
 
 ### Range
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,7 +1,7 @@
 ---
 title: Analytics
-short_description: Build dashboard analytics on a Sigmie index — KPIs, period-over-period deltas, time-series trends, breakdowns, distributions, percentiles, cumulative growth, funnels, cohort retention, heatmaps, geo maps and document tables — and expose them to AI agents.
-keywords: [analytics, dashboard, trends, KPI, time series, breakdown, histogram, percentiles, funnel, retention, cohort, heatmap, geo, table, multi-search, AI agent]
+short_description: Build live Elasticsearch analytics with Sigmie using KPIs, trends, ranked breakdowns, cross-field unions, cohorts, funnels, tables, and AI tools.
+keywords: [analytics, dashboard, trends, KPI, time series, breakdown, union breakdown, histogram, percentiles, funnel, retention, cohort, heatmap, geo, table, multi-search, AI agent]
 category: Features
 order: 3
 related_pages: [aggregations, facets, laravel-ai]
@@ -101,6 +101,20 @@ $orders->analytics('created_at')
 // ]]]
 ```
 
+For a grouped event count, no numeric metric field is needed. Pass an empty field to the PHP API; the AI analytics tool accepts `field: null` for the same request:
+
+```php
+$events->analytics('occurred_at')
+    ->groupedTrend(
+        'events_by_type',
+        Metric::Count,
+        field: '',
+        groupBy: 'event_type',
+        interval: CalendarInterval::Day,
+    )
+    ->get();
+```
+
 ### Breakdown — top-N ranked list
 
 A dimension ranked by a metric ("top products by revenue", "top issues by event count").
@@ -114,6 +128,66 @@ $orders->analytics('created_at')
 //     ['key' => 'A', 'value' => 370.0, 'count' => 3], ...
 // ]]]
 ```
+
+Ranked widgets order by their computed metric. Use `direction: 'asc'` to return the lowest values first:
+
+```php
+$orders->analytics('created_at')
+    ->breakdown('smallest_queues', 'queue', Metric::Count, limit: 5, direction: 'asc')
+    ->get();
+```
+
+The AI analytics tool expresses the same choice as `sort: "metric:asc"` or `sort: "metric:desc"`. This is intentionally different from a table's `field:direction` sort.
+
+### Multi breakdown — rank combinations
+
+`multiBreakdown()` keeps every field as a separate part of a composite key. Use it when `product + channel` is the entity being ranked:
+
+```php
+$orders->analytics('created_at')
+    ->multiBreakdown(
+        'top_product_channels',
+        ['product', 'channel'],
+        Metric::Sum,
+        field: 'amount',
+        limit: 10,
+    )
+    ->get();
+
+// ['top_product_channels' => ['rows' => [
+//     ['key' => ['product' => 'A', 'channel' => 'online'],
+//      'key_values' => ['A', 'online'], 'label' => 'A / online',
+//      'value' => 240.0, 'count' => 2], ...
+// ]]]
+```
+
+### Union breakdown — one label across fields
+
+`unionBreakdown()` treats compatible fields as different roles for one logical label. A country stored as either `champion_country` or `runner_up_country` contributes to one country bucket, so callers do not need to merge separate breakdowns:
+
+```php
+$tournaments->analytics('played_at')
+    ->unionBreakdown(
+        'country_appearances',
+        ['champion_country', 'runner_up_country'],
+        Metric::Count,
+        limit: 10,
+    )
+    ->unionBreakdown(
+        'country_prize',
+        ['champion_country', 'runner_up_country'],
+        Metric::Sum,
+        field: 'prize',
+        limit: 10,
+    )
+    ->get();
+
+// ['country_appearances' => ['rows' => [
+//     ['key' => 'Germany', 'value' => 4, 'count' => 4], ...
+// ]]]
+```
+
+The fields must have compatible aggregatable mapping types. When the same label appears in more than one configured field on one document, that document contributes to the label only once. `limit` and `direction` work like the other ranked breakdown widgets. For the lower-level aggregation API, see [union terms](aggregations.md#union-terms).
 
 ### Distribution — histogram of a numeric field
 
@@ -395,7 +469,7 @@ $dashboard = $analytics->formatResponse($metrics);
 
 ## Analytics for AI agents
 
-Add [`AsTool`](laravel-ai.md) to an index and its `tools()` suite includes an `analytics` tool. The agent picks a `widget` — `kpi`, `kpi_delta`, `trend`, `cumulative`, `grouped_trend`, `breakdown`, `distribution`, `percentiles`, `stats`, `table`, `funnel`, `heatmap`, `retention` or `geo` — and arguments; "give me sales this month as a chart" becomes a `trend` call, and "show it per month instead" is the **same call with `interval: month`** — the agent adapts one argument and re-runs. The tool's description carries a grounded example per widget (using the index's own fields), so the model sees the exact argument shape each one expects.
+Add [`AsTool`](laravel-ai.md) to an index and its `tools()` suite includes an `analytics` tool. The agent picks a `widget`, including `grouped_trend`, `breakdown`, `multi_breakdown`, and `union_breakdown`, plus its arguments. "Give me sales this month as a chart" becomes a `trend` call, and "show it per month instead" is the **same call with `interval: month`** — the agent adapts one argument and re-runs. The tool's description carries a grounded example per widget (using the index's own fields), so the model sees the exact argument shape each one expects.
 
 ```php
 class OrderIndex extends SigmieIndex
@@ -414,4 +488,4 @@ public function tools(): array
 }
 ```
 
-The agent supplies the `date_field` (validated against the index's date fields), the `metric`/`field` (from its numeric fields), and optionally a `range` (`this_month`, `last_7_days`, …) and `timezone_offset` (minutes east of UTC) so charts land in the user's local time. When the user asks for a metric/chart and examples or rows behind it, the agent can set `include_hits=1`, plus optional `hit_fields`, `hit_sort`, `hit_limit`, and `hit_filters`. As with the other tools, the optional `$baseFilter` is server-controlled scoping — AND-ed into every query and never taken from the agent — so an agent can only ever see its own slice of the data.
+The agent supplies the `date_field` (validated against the index's date fields), the `metric`/`field` (from its numeric fields), and optionally a `range` (`this_month`, `last_7_days`, …) and `timezone_offset` (minutes east of UTC) so charts land in the user's local time. A count-based `grouped_trend` may pass `field: null`. Ranked widgets use `sort: "metric:asc"` or `sort: "metric:desc"`; `union_breakdown` passes at least two compatible fields in `group_by_fields`. When the user asks for a metric/chart and examples or rows behind it, the agent can set `include_hits=1`, plus optional `hit_fields`, `hit_sort`, `hit_limit`, and `hit_filters`. As with the other tools, the optional `$baseFilter` is server-controlled scoping — AND-ed into every query and never taken from the agent — so an agent can only ever see its own slice of the data.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -189,6 +189,37 @@ $tournaments->analytics('played_at')
 
 The fields must have compatible aggregatable mapping types. When the same label appears in more than one configured field on one document, that document contributes to the label only once. `limit` and `direction` work like the other ranked breakdown widgets. For the lower-level aggregation API, see [union terms](aggregations.md#union-terms).
 
+### Grouped metrics — several measures per group
+
+`groupedMetrics()` ranks one dimension by a selected metric while returning additional measures for every group. Use it for charts or tables such as "products ranked by order count, with average order value alongside it". `minCount` removes groups whose document population is too small to be useful.
+
+```php
+$orders->analytics('created_at')
+    ->groupedMetrics(
+        'product_metrics',
+        groupBy: 'product',
+        metrics: [
+            ['key' => 'orders', 'label' => 'Orders', 'metric' => Metric::Count],
+            ['key' => 'average_amount', 'label' => 'Average amount', 'metric' => Metric::Avg, 'field' => 'amount'],
+        ],
+        sortMetric: 'orders',
+        limit: 10,
+        minCount: 2,
+    )
+    ->get();
+
+// ['product_metrics' => ['rows' => [
+//     ['key' => 'A', 'value' => 3, 'count' => 3,
+//      'metrics' => ['orders' => 3, 'average_amount' => 123.33],
+//      'metric_populations' => [
+//          'orders' => ['document_count' => 3, 'value_count' => 3, 'field' => ''],
+//          'average_amount' => ['document_count' => 3, 'value_count' => 3, 'field' => 'amount'],
+//      ]], ...
+// ]]]
+```
+
+Every metric has a stable `key` used by `sortMetric` and in each row's `metrics` map. Non-count metrics require a numeric `field`. `metric_populations` distinguishes the group's full document population from the rows where a metric field has a value, which makes missing values visible instead of silently presenting an average as if it covered every document. Use `direction: 'asc'` for the lowest metric first.
+
 ### Distribution — histogram of a numeric field
 
 ```php
@@ -198,6 +229,34 @@ $orders->analytics('created_at')
 
 // ['order_sizes' => ['buckets' => [['label' => 0, 'count' => 3], ['label' => 100, 'count' => 1], ...]]]
 ```
+
+### Histogram metric — a measure inside numeric buckets
+
+`histogramMetric()` first divides a numeric `bucketField` into fixed-width ranges, then computes a metric inside each range. Unlike `distribution()`, which only counts documents, this can answer questions such as "what is the average rating for each price band?"
+
+```php
+$products->analytics('created_at')
+    ->histogramMetric(
+        'average_rating_by_price',
+        bucketField: 'price',
+        interval: 50,
+        metric: Metric::Avg,
+        field: 'rating',
+    )
+    ->get();
+
+// ['average_rating_by_price' => [
+//     'type' => 'histogram_metric',
+//     'bucket_field' => 'price',
+//     'interval' => 50,
+//     'series' => [
+//         ['label' => 0, 'value' => 4.2, 'count' => 18],
+//         ['label' => 50, 'value' => 4.6, 'count' => 7], ...
+//     ],
+// ]]
+```
+
+Each `label` is the lower bound of its numeric bucket: `50` represents values from 50 up to, but not including, 100. `value` is the requested metric and `count` is the number of documents in that bucket, so a chart can display both the result and its supporting population.
 
 ### Percentiles — p50 / p75 / p95 / p99
 

--- a/src/AI/SigmieAnalyticsTool.php
+++ b/src/AI/SigmieAnalyticsTool.php
@@ -69,6 +69,7 @@ class SigmieAnalyticsTool implements Tool
             ."- grouped_trend: one trend line per value of group_by — stacked chart (needs metric, field, group_by, interval)\n"
             ."- breakdown: top-N group_by values ranked by a metric (needs group_by, metric, field)\n"
             ."- multi_breakdown: top-N combinations of group_by_fields ranked by a metric (needs group_by_fields, metric, field)\n"
+            ."- union_breakdown: top-N labels combined across group_by_fields and ranked by a metric (needs group_by_fields, metric, field)\n"
             ."- distribution: histogram of a numeric field (needs field, bucket_size)\n"
             ."- histogram_metric: metric aggregated inside numeric buckets (needs bucket_field, bucket_size, metric, field)\n"
             ."- grouped_metrics: one row per group carrying several metrics (needs group_by, metrics, sort_metric, min_count)\n"
@@ -90,6 +91,7 @@ class SigmieAnalyticsTool implements Tool
             ."- \"running total\", \"cumulative X\", \"growth curve\" → cumulative\n"
             ."- \"top N <thing> by X\", \"best <thing>\", \"which <thing> drove the most X\" → breakdown (group_by=<thing>)\n"
             ."- \"top N <thing> by <dimension> by X\", \"best <dim1> + <dim2> combinations\", \"rank combinations\" -> multi_breakdown (group_by_fields=<dim1>,<dim2>)\n"
+            ."- \"combine the same label across roles\", \"count appearances across fields\" -> union_breakdown (group_by_fields=<role1>,<role2>)\n"
             ."- \"average/sum/etc. X by numeric buckets of Y\", \"average rating by calorie bucket\" → histogram_metric (bucket_field=Y, field=X)\n"
             ."- \"rank groups by count and show average X\", \"groups with at least N rows plus another metric\" → grouped_metrics\n"
             ."- \"X this month\" / \"average X last week\" with no bucket word → kpi (or kpi_delta when the user compares to a prior period)\n"
@@ -153,6 +155,7 @@ class SigmieAnalyticsTool implements Tool
             'top 5 groups by total' => ['widget' => 'breakdown', 'date_field' => $date, 'group_by' => $keyword, 'metric' => 'sum', 'field' => $number, 'limit' => 5, 'range' => 'this_month'],
             'top groups with merged labels' => ['widget' => 'breakdown', 'date_field' => $date, 'group_by' => $keyword, 'metric' => 'sum', 'field' => $number, 'limit' => 5, 'range' => 'this_month', 'bucket_aliases' => '[{"label":"Combined","values":["Old name","New name"]}]'],
             'top combinations by total' => ['widget' => 'multi_breakdown', 'date_field' => $date, 'group_by_fields' => sprintf('%s,%s', $keyword, $keyword2), 'metric' => 'sum', 'field' => $number, 'limit' => 5, 'range' => 'this_month'],
+            'top labels across fields' => ['widget' => 'union_breakdown', 'date_field' => $date, 'group_by_fields' => sprintf('%s,%s', $keyword, $keyword2), 'metric' => 'sum', 'field' => $number, 'limit' => 5, 'range' => 'this_month'],
             'histogram of a number' => ['widget' => 'distribution', 'date_field' => $date, 'field' => $number, 'bucket_size' => 100, 'range' => 'this_month'],
             'average by numeric bucket' => ['widget' => 'histogram_metric', 'date_field' => $date, 'bucket_field' => $number, 'field' => $number, 'metric' => 'avg', 'bucket_size' => 100, 'range' => 'this_month'],
             'top groups with two metrics' => ['widget' => 'grouped_metrics', 'date_field' => $date, 'group_by' => $keyword, 'metrics' => '[{"key":"count","label":"Count","metric":"count"},{"key":"avg_amount","label":"Average amount","metric":"avg","field":"'.$number.'"}]', 'sort_metric' => 'count', 'min_count' => 2, 'limit' => 5, 'range' => 'this_month'],
@@ -181,7 +184,7 @@ class SigmieAnalyticsTool implements Tool
         // `widget` and `date_field` are plain required; every optional param is `nullable()->required()`
         // so the schema stays valid under OpenAI's strict function-calling (callers pass null to omit).
         return [
-            'widget' => $schema->string()->description('kpi | kpi_delta | trend | cumulative | grouped_trend | breakdown | multi_breakdown | distribution | histogram_metric | grouped_metrics | percentiles | stats | table | funnel | heatmap | retention | geo')->required(),
+            'widget' => $schema->string()->description('kpi | kpi_delta | trend | cumulative | grouped_trend | breakdown | multi_breakdown | union_breakdown | distribution | histogram_metric | grouped_metrics | percentiles | stats | table | funnel | heatmap | retention | geo')->required(),
             'date_field' => $schema->string()->description('Timeline (date) field to bucket/scope by')->required(),
             'metric' => $schema->string()->description('sum | avg | min | max | count | unique | median (pass null for distribution, percentiles, stats, table, funnel, retention, geo; optional for heatmap — defaults to count)')->nullable()->required(),
             'field' => $schema->string()->description('Numeric field the metric is computed on; also the numeric field for stats and the geo_point field for the geo widget (pass null for count)')->nullable()->required(),
@@ -192,7 +195,7 @@ class SigmieAnalyticsTool implements Tool
             'interval' => $schema->string()->description('Time bucket for trends and retention: a calendar unit (minute | hour | day | week | month | quarter | year) or a fixed interval like 15d | 12h | 90m (default day)')->default('day')->nullable()->required(),
             'min_doc_count' => $schema->integer()->description('Minimum documents per trend bucket. Use 1 to omit empty periods; pass null otherwise.')->nullable()->required(),
             'group_by' => $schema->string()->description('Keyword field to group/break down by, for breakdown and grouped_trend (pass null otherwise)')->nullable()->required(),
-            'group_by_fields' => $schema->string()->description('Comma-separated keyword fields for multi_breakdown, e.g. "product,channel" (pass null otherwise)')->nullable()->required(),
+            'group_by_fields' => $schema->string()->description('Comma-separated compatible keyword fields for multi_breakdown or union_breakdown, e.g. "champion_country,runner_up_country" (pass null otherwise)')->nullable()->required(),
             'limit' => $schema->integer()->description('Max groups for breakdown/grouped_trend, rows for table, or cells per axis for heatmap (default 10)')->default(10)->nullable()->required(),
             'bucket_size' => $schema->integer()->description('Bucket width for the distribution widget (pass null otherwise)')->nullable()->required(),
             'percents' => $schema->string()->description('Comma-separated percentiles for the percentiles widget, e.g. "50,75,95,99" (pass null for the default)')->nullable()->required(),
@@ -295,7 +298,8 @@ class SigmieAnalyticsTool implements Tool
             'cumulative' => $analytics->cumulative('result', $metric(), $field, $interval()),
             'grouped_trend' => $analytics->groupedTrend('result', $metric(), $this->required($request, 'field'), $groupBy(), $interval(), $limit),
             'breakdown' => $analytics->breakdown('result', $groupBy(), $metric(), $field, $limit, bucketAliases: $this->bucketAliases($request)),
-            'multi_breakdown' => $analytics->multiBreakdown('result', $this->groupByFields($request), $metric(), $field, $limit),
+            'multi_breakdown' => $analytics->multiBreakdown('result', $this->groupByFields($request, $widget), $metric(), $field, $limit),
+            'union_breakdown' => $analytics->unionBreakdown('result', $this->groupByFields($request, $widget), $metric(), $field, $limit),
             'distribution' => $analytics->distribution('result', $this->required($request, 'field'), (int) ($request['bucket_size'] ?? throw new InvalidArgumentException('The distribution widget requires bucket_size.'))),
             'histogram_metric' => $analytics->histogramMetric('result', $this->required($request, 'bucket_field'), (int) ($request['bucket_size'] ?? throw new InvalidArgumentException('The histogram_metric widget requires bucket_size.')), $metric(), $this->required($request, 'field')),
             'grouped_metrics' => $analytics->groupedMetrics('result', $groupBy(), $this->metricSpecs($request), $this->optional($request, 'sort_metric') ?? 'count', $limit, minCount: max(0, (int) ($request['min_count'] ?? 0)), bucketAliases: $this->bucketAliases($request), aliasesOnly: (bool) ($request['bucket_aliases_only'] ?? false)),
@@ -306,7 +310,7 @@ class SigmieAnalyticsTool implements Tool
             'heatmap' => $analytics->heatmap('result', $this->required($request, 'row_field'), $this->required($request, 'col_field'), $this->metricOrCount($request), $field, $limit, $limit),
             'retention' => $analytics->retention('result', $this->required($request, 'cohort_field'), $this->required($request, 'id_field'), $interval()),
             'geo' => $analytics->geo('result', $this->required($request, 'field'), max(1, (int) ($request['precision'] ?? 5))),
-            default => throw new InvalidArgumentException(sprintf("Unknown widget '%s'. Use one of: kpi, kpi_delta, trend, cumulative, grouped_trend, breakdown, multi_breakdown, distribution, histogram_metric, grouped_metrics, percentiles, stats, table, funnel, heatmap, retention, geo.", $widget)),
+            default => throw new InvalidArgumentException(sprintf("Unknown widget '%s'. Use one of: kpi, kpi_delta, trend, cumulative, grouped_trend, breakdown, multi_breakdown, union_breakdown, distribution, histogram_metric, grouped_metrics, percentiles, stats, table, funnel, heatmap, retention, geo.", $widget)),
         };
     }
 
@@ -460,11 +464,13 @@ class SigmieAnalyticsTool implements Tool
     /**
      * @return list<string>
      */
-    protected function groupByFields(Request $request): array
+    protected function groupByFields(Request $request, string $widget): array
     {
         $fields = $this->csvList($request, 'group_by_fields');
 
-        return count($fields) >= 2 ? $fields : throw new InvalidArgumentException('The multi_breakdown widget requires at least two group_by_fields.');
+        return count($fields) >= 2
+            ? $fields
+            : throw new InvalidArgumentException(sprintf('The %s widget requires at least two group_by_fields.', $widget));
     }
 
     /**

--- a/src/AI/SigmieAnalyticsTool.php
+++ b/src/AI/SigmieAnalyticsTool.php
@@ -200,7 +200,7 @@ class SigmieAnalyticsTool implements Tool
             'bucket_size' => $schema->integer()->description('Bucket width for the distribution widget (pass null otherwise)')->nullable()->required(),
             'percents' => $schema->string()->description('Comma-separated percentiles for the percentiles widget, e.g. "50,75,95,99" (pass null for the default)')->nullable()->required(),
             'fields' => $schema->string()->description('Comma-separated source fields to return for the table widget, e.g. "id,amount" (pass null for the full document)')->nullable()->required(),
-            'sort' => $schema->string()->description('Sort for the table widget as "field:dir", e.g. "amount:desc" (pass null for default descending)')->nullable()->required(),
+            'sort' => $schema->string()->description('Use "metric:asc" or "metric:desc" for ranked breakdown/grouped_metrics widgets; use "field:dir" for table, e.g. "amount:desc" (pass null for descending/default order)')->nullable()->required(),
             'steps' => $schema->string()->description('Funnel steps as an ORDERED JSON array of {label, filter} objects, e.g. [{"label":"visited","filter":"event:\'visit\'"},{"label":"paid","filter":"event:\'paid\'"}] (pass null otherwise)')->nullable()->required(),
             'row_field' => $schema->string()->description('Heatmap row dimension — a keyword field (pass null otherwise)')->nullable()->required(),
             'col_field' => $schema->string()->description('Heatmap column dimension — a keyword field (pass null otherwise)')->nullable()->required(),
@@ -297,12 +297,12 @@ class SigmieAnalyticsTool implements Tool
             'trend' => $analytics->trend('result', $metric(), $field, $interval(), minDocCount: max(0, (int) ($request['min_doc_count'] ?? 0))),
             'cumulative' => $analytics->cumulative('result', $metric(), $field, $interval()),
             'grouped_trend' => $analytics->groupedTrend('result', $metric(), $this->required($request, 'field'), $groupBy(), $interval(), $limit),
-            'breakdown' => $analytics->breakdown('result', $groupBy(), $metric(), $field, $limit, bucketAliases: $this->bucketAliases($request)),
-            'multi_breakdown' => $analytics->multiBreakdown('result', $this->groupByFields($request, $widget), $metric(), $field, $limit),
-            'union_breakdown' => $analytics->unionBreakdown('result', $this->groupByFields($request, $widget), $metric(), $field, $limit),
+            'breakdown' => $analytics->breakdown('result', $groupBy(), $metric(), $field, $limit, $this->rankingDirection($request), bucketAliases: $this->bucketAliases($request)),
+            'multi_breakdown' => $analytics->multiBreakdown('result', $this->groupByFields($request, $widget), $metric(), $field, $limit, $this->rankingDirection($request)),
+            'union_breakdown' => $analytics->unionBreakdown('result', $this->groupByFields($request, $widget), $metric(), $field, $limit, $this->rankingDirection($request)),
             'distribution' => $analytics->distribution('result', $this->required($request, 'field'), (int) ($request['bucket_size'] ?? throw new InvalidArgumentException('The distribution widget requires bucket_size.'))),
             'histogram_metric' => $analytics->histogramMetric('result', $this->required($request, 'bucket_field'), (int) ($request['bucket_size'] ?? throw new InvalidArgumentException('The histogram_metric widget requires bucket_size.')), $metric(), $this->required($request, 'field')),
-            'grouped_metrics' => $analytics->groupedMetrics('result', $groupBy(), $this->metricSpecs($request), $this->optional($request, 'sort_metric') ?? 'count', $limit, minCount: max(0, (int) ($request['min_count'] ?? 0)), bucketAliases: $this->bucketAliases($request), aliasesOnly: (bool) ($request['bucket_aliases_only'] ?? false)),
+            'grouped_metrics' => $analytics->groupedMetrics('result', $groupBy(), $this->metricSpecs($request), $this->optional($request, 'sort_metric') ?? 'count', $limit, $this->rankingDirection($request), minCount: max(0, (int) ($request['min_count'] ?? 0)), bucketAliases: $this->bucketAliases($request), aliasesOnly: (bool) ($request['bucket_aliases_only'] ?? false)),
             'percentiles' => $analytics->percentiles('result', $this->required($request, 'field'), $this->percents($request)),
             'stats' => $analytics->stats('result', $this->required($request, 'field')),
             'table' => $analytics->table('result', $this->csvList($request, 'fields'), $limit, $this->optional($request, 'sort')),
@@ -312,6 +312,17 @@ class SigmieAnalyticsTool implements Tool
             'geo' => $analytics->geo('result', $this->required($request, 'field'), max(1, (int) ($request['precision'] ?? 5))),
             default => throw new InvalidArgumentException(sprintf("Unknown widget '%s'. Use one of: kpi, kpi_delta, trend, cumulative, grouped_trend, breakdown, multi_breakdown, union_breakdown, distribution, histogram_metric, grouped_metrics, percentiles, stats, table, funnel, heatmap, retention, geo.", $widget)),
         };
+    }
+
+    protected function rankingDirection(Request $request): string
+    {
+        $sort = trim((string) ($request['sort'] ?? ''));
+        [, $direction] = array_pad(explode(':', $sort, 2), 2, 'desc');
+        $direction = strtolower(trim($direction));
+
+        return in_array($direction, ['asc', 'desc'], true)
+            ? $direction
+            : throw new InvalidArgumentException(sprintf('Unsupported analytics ranking direction [%s].', $direction));
     }
 
     protected function dateField(string $field): string

--- a/src/AI/SigmieAnalyticsTool.php
+++ b/src/AI/SigmieAnalyticsTool.php
@@ -66,7 +66,7 @@ class SigmieAnalyticsTool implements Tool
             ."- kpi_delta: kpi plus % change vs the previous equal-length period (needs metric, field)\n"
             ."- trend: a metric over time — line/area/bar (needs metric, field, interval)\n"
             ."- cumulative: running total over time — growth curve (needs metric, field, interval)\n"
-            ."- grouped_trend: one trend line per value of group_by — stacked chart (needs metric, field, group_by, interval)\n"
+            ."- grouped_trend: one trend line per value of group_by — stacked chart (needs metric, group_by, interval; field is optional for count)\n"
             ."- breakdown: top-N group_by values ranked by a metric (needs group_by, metric, field)\n"
             ."- multi_breakdown: top-N combinations of group_by_fields ranked by a metric (needs group_by_fields, metric, field)\n"
             ."- union_breakdown: top-N labels combined across group_by_fields and ranked by a metric (needs group_by_fields, metric, field)\n"
@@ -296,7 +296,7 @@ class SigmieAnalyticsTool implements Tool
             'kpi_delta' => $analytics->kpiDelta('result', $metric(), $field),
             'trend' => $analytics->trend('result', $metric(), $field, $interval(), minDocCount: max(0, (int) ($request['min_doc_count'] ?? 0))),
             'cumulative' => $analytics->cumulative('result', $metric(), $field, $interval()),
-            'grouped_trend' => $analytics->groupedTrend('result', $metric(), $this->required($request, 'field'), $groupBy(), $interval(), $limit),
+            'grouped_trend' => $analytics->groupedTrend('result', $metric(), $field, $groupBy(), $interval(), $limit),
             'breakdown' => $analytics->breakdown('result', $groupBy(), $metric(), $field, $limit, $this->rankingDirection($request), bucketAliases: $this->bucketAliases($request)),
             'multi_breakdown' => $analytics->multiBreakdown('result', $this->groupByFields($request, $widget), $metric(), $field, $limit, $this->rankingDirection($request)),
             'union_breakdown' => $analytics->unionBreakdown('result', $this->groupByFields($request, $widget), $metric(), $field, $limit, $this->rankingDirection($request)),

--- a/src/Analytics/Analytics.php
+++ b/src/Analytics/Analytics.php
@@ -27,6 +27,7 @@ use Sigmie\Analytics\Widgets\Retention;
 use Sigmie\Analytics\Widgets\StatSummary;
 use Sigmie\Analytics\Widgets\Table;
 use Sigmie\Analytics\Widgets\Trend;
+use Sigmie\Analytics\Widgets\UnionBreakdown;
 use Sigmie\Analytics\Widgets\Widget;
 use Sigmie\Mappings\NewProperties;
 use Sigmie\Mappings\Properties;
@@ -269,6 +270,23 @@ class Analytics implements MultiSearchable
         ));
 
         return $this->addFiltered(new MultiBreakdown($as, $this->dateField, $from, $to, $this->dateFormat, $resolvedGroupBy, $metric, $this->metricField($metric, $field), $limit, $direction), $filter);
+    }
+
+    /**
+     * Add a top-N ranked list that unions the same labels across several grouping fields.
+     *
+     * @param  list<string>  $groupBy
+     */
+    public function unionBreakdown(string $as, array $groupBy, Metric $metric, string $field = '', int $limit = 10, string $direction = 'desc', Query|string|null $filter = null, Period|array|null $window = null): static
+    {
+        [$from, $to] = $this->resolveWindow($window);
+
+        $resolvedGroupBy = array_values(array_map(
+            fn (string $field): string => $this->aggregatableField($field),
+            $groupBy,
+        ));
+
+        return $this->addFiltered(new UnionBreakdown($as, $this->dateField, $from, $to, $this->dateFormat, $resolvedGroupBy, $metric, $this->metricField($metric, $field), $limit, $direction), $filter);
     }
 
     public function distribution(string $as, string $field, int $interval, Query|string|null $filter = null, Period|array|null $window = null): static

--- a/src/Analytics/AnalyticsRequest.php
+++ b/src/Analytics/AnalyticsRequest.php
@@ -369,7 +369,7 @@ class AnalyticsRequest
         }
 
         match ($widget) {
-            'grouped_trend' => self::requireMany($request, ['group_by', 'field']),
+            'grouped_trend' => self::required($request, 'group_by'),
             'breakdown' => self::required($request, 'group_by'),
             'multi_breakdown' => self::required($request, 'group_by_fields'),
             'union_breakdown' => self::required($request, 'group_by_fields'),

--- a/src/Analytics/AnalyticsRequest.php
+++ b/src/Analytics/AnalyticsRequest.php
@@ -20,6 +20,7 @@ class AnalyticsRequest
         'grouped_trend',
         'breakdown',
         'multi_breakdown',
+        'union_breakdown',
         'distribution',
         'histogram_metric',
         'grouped_metrics',
@@ -337,6 +338,7 @@ class AnalyticsRequest
             'grouped_trend',
             'breakdown',
             'multi_breakdown',
+            'union_breakdown',
             'histogram_metric',
         ];
 
@@ -370,6 +372,7 @@ class AnalyticsRequest
             'grouped_trend' => self::requireMany($request, ['group_by', 'field']),
             'breakdown' => self::required($request, 'group_by'),
             'multi_breakdown' => self::required($request, 'group_by_fields'),
+            'union_breakdown' => self::required($request, 'group_by_fields'),
             'distribution' => self::requireMany($request, ['field', 'bucket_size']),
             'percentiles', 'stats', 'geo' => self::required($request, 'field'),
             'histogram_metric' => self::requireMany($request, ['bucket_field', 'bucket_size', 'field']),
@@ -406,8 +409,16 @@ class AnalyticsRequest
      */
     private static function validateStructuredValues(array $request, string $widget): void
     {
-        if (isset($request['group_by_fields']) && count(self::csvValues($request, 'group_by_fields')) < 2) {
-            throw new InvalidArgumentException('The multi_breakdown widget requires at least two group_by_fields.');
+        if (isset($request['group_by_fields'])) {
+            $groupByFields = self::csvValues($request, 'group_by_fields');
+
+            if (count($groupByFields) < 2) {
+                throw new InvalidArgumentException(sprintf('The %s widget requires at least two group_by_fields.', $widget));
+            }
+
+            if ($widget === 'union_breakdown' && count(array_unique($groupByFields)) < 2) {
+                throw new InvalidArgumentException('The union_breakdown widget requires at least two distinct group_by_fields.');
+            }
         }
 
         if (isset($request['percents'])) {

--- a/src/Analytics/QueryRecipe.php
+++ b/src/Analytics/QueryRecipe.php
@@ -72,6 +72,9 @@ class QueryRecipe
     /** @var list<string> */
     private const LIMIT_WIDGETS = ['grouped_trend', 'breakdown', 'multi_breakdown', 'union_breakdown', 'grouped_metrics', 'table', 'heatmap'];
 
+    /** @var list<string> */
+    private const RANKING_WIDGETS = ['breakdown', 'multi_breakdown', 'union_breakdown', 'grouped_metrics'];
+
     /**
      * @param  array<string, mixed>  $definition
      */
@@ -213,7 +216,7 @@ class QueryRecipe
             }
         }
 
-        if (($template['sort'] ?? '') !== '') {
+        if (($template['sort'] ?? '') !== '' && ! in_array($widget, self::RANKING_WIDGETS, true)) {
             $this->validateSort($properties, (string) $template['sort'], 'sort', false);
         }
 
@@ -297,7 +300,7 @@ class QueryRecipe
             fn (array $slot): array => self::normalizeSlot($slot),
             $definition['slots'] ?? [],
         ));
-        $validationTemplate = $definition['template'] ?? [];
+        $validationTemplate = self::normalizeRankingSort($definition['template'] ?? []);
         $limitSlotIndex = null;
 
         foreach ($slots as $index => $slot) {
@@ -367,6 +370,29 @@ class QueryRecipe
             'slots' => $slots,
             'filter_templates' => $filters,
         ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $template
+     * @return array<string, mixed>
+     */
+    private static function normalizeRankingSort(array $template): array
+    {
+        if (! in_array((string) ($template['widget'] ?? ''), self::RANKING_WIDGETS, true)) {
+            return $template;
+        }
+
+        $sort = trim((string) ($template['sort'] ?? ''));
+        [, $direction] = array_pad(explode(':', $sort, 2), 2, 'desc');
+        $direction = strtolower(trim($direction));
+
+        if (! in_array($direction, ['asc', 'desc'], true)) {
+            throw new InvalidArgumentException(sprintf('Unsupported query recipe ranking direction [%s].', $direction));
+        }
+
+        $template['sort'] = "metric:{$direction}";
+
+        return $template;
     }
 
     /**

--- a/src/Analytics/QueryRecipe.php
+++ b/src/Analytics/QueryRecipe.php
@@ -70,7 +70,7 @@ class QueryRecipe
     private const DEFINITION_KEYS = ['version', 'dataset', 'template', 'slots', 'filter_templates'];
 
     /** @var list<string> */
-    private const LIMIT_WIDGETS = ['grouped_trend', 'breakdown', 'multi_breakdown', 'grouped_metrics', 'table', 'heatmap'];
+    private const LIMIT_WIDGETS = ['grouped_trend', 'breakdown', 'multi_breakdown', 'union_breakdown', 'grouped_metrics', 'table', 'heatmap'];
 
     /**
      * @param  array<string, mixed>  $definition
@@ -197,8 +197,14 @@ class QueryRecipe
             }
         }
 
-        foreach ($this->csvFields((string) ($template['group_by_fields'] ?? '')) as $field) {
+        $groupByFields = $this->csvFields((string) ($template['group_by_fields'] ?? ''));
+
+        foreach ($groupByFields as $field) {
             $this->requireFieldType($fields, $field, ['keyword', 'text', 'number', 'boolean'], 'group_by_fields');
+        }
+
+        if ($widget === 'union_breakdown') {
+            $this->validateUnionGroupFields($fields, $groupByFields);
         }
 
         foreach (['fields', 'hit_fields'] as $key) {
@@ -891,6 +897,24 @@ class QueryRecipe
         $this->requireField($fields, $field, $argument);
         if (! in_array($fields[$field], $types, true)) {
             throw new InvalidArgumentException(sprintf('Query recipe %s field [%s] has incompatible type [%s].', $argument, $field, $fields[$field]));
+        }
+    }
+
+    /**
+     * @param  array<string, string>  $fields
+     * @param  list<string>  $groupByFields
+     */
+    private function validateUnionGroupFields(array $fields, array $groupByFields): void
+    {
+        $types = array_values(array_unique(array_map(
+            fn (string $field): string => in_array($fields[$field], ['keyword', 'text'], true)
+                ? 'string'
+                : $fields[$field],
+            $groupByFields,
+        )));
+
+        if (count($types) > 1) {
+            throw new InvalidArgumentException('Query recipe union_breakdown group_by_fields must have compatible types.');
         }
     }
 

--- a/src/Analytics/QueryRecipe.php
+++ b/src/Analytics/QueryRecipe.php
@@ -390,7 +390,7 @@ class QueryRecipe
             throw new InvalidArgumentException(sprintf('Unsupported query recipe ranking direction [%s].', $direction));
         }
 
-        $template['sort'] = "metric:{$direction}";
+        $template['sort'] = sprintf('metric:%s', $direction);
 
         return $template;
     }

--- a/src/Analytics/Widgets/UnionBreakdown.php
+++ b/src/Analytics/Widgets/UnionBreakdown.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\Analytics\Widgets;
+
+use DateTimeInterface;
+use Sigmie\Analytics\Enums\Metric;
+use Sigmie\Query\Aggs;
+use Sigmie\Shared\Collection;
+
+class UnionBreakdown extends Widget
+{
+    /**
+     * @param  list<string>  $groupBy
+     */
+    public function __construct(
+        string $name,
+        string $dateField,
+        DateTimeInterface $from,
+        DateTimeInterface $to,
+        string $dateFormat,
+        protected array $groupBy,
+        protected Metric $metric,
+        protected string $field,
+        protected int $limit,
+        protected string $direction,
+    ) {
+        parent::__construct($name, $dateField, $from, $to, $dateFormat);
+    }
+
+    public function toRaw(): array
+    {
+        return $this->scoped($this->name, $this->from, $this->to, function (Aggs $aggs): void {
+            $aggs->unionTerms('groups', $this->groupBy)
+                ->size($this->limit)
+                ->order($this->metric->orderKey('metric'), $this->direction)
+                ->aggregate(fn (Aggs $sub) => $this->addMetric($sub));
+        })->toRaw();
+    }
+
+    public function extract(array $aggregations): array
+    {
+        $groups = new Collection($aggregations[$this->name]['groups']['buckets'] ?? []);
+
+        return [
+            'type' => 'union_breakdown',
+            'metric' => $this->metric->value,
+            'field' => $this->field,
+            'group_by_fields' => $this->groupBy,
+            'rows' => $groups->map(fn (array $bucket): array => [
+                'key' => $bucket['key'],
+                'value' => $this->metric->extract($bucket['metric'] ?? []),
+                'count' => $bucket['doc_count'] ?? 0,
+                'population' => $this->metricPopulation($bucket),
+            ])->toArray(),
+        ];
+    }
+
+    protected function addMetric(Aggs $aggs): void
+    {
+        $this->metric->apply($aggs, 'metric', $this->field);
+
+        if ($this->metric !== Metric::Count) {
+            $aggs->valueCount('metric_population', $this->field);
+        }
+    }
+
+    /** @return array{document_count: int, value_count: int, field: string} */
+    protected function metricPopulation(array $bucket): array
+    {
+        $documentCount = (int) ($bucket['doc_count'] ?? 0);
+
+        return [
+            'document_count' => $documentCount,
+            'value_count' => $this->metric === Metric::Count
+                ? $documentCount
+                : (int) ($bucket['metric_population']['value'] ?? 0),
+            'field' => $this->field,
+        ];
+    }
+}

--- a/src/Query/Aggregations/Bucket/UnionTerms.php
+++ b/src/Query/Aggregations/Bucket/UnionTerms.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\Query\Aggregations\Bucket;
+
+class UnionTerms extends Bucket
+{
+    private const SCRIPT = <<<'PAINLESS'
+def values = new HashSet();
+
+for (def field : params.fields) {
+    if (!doc.containsKey(field) || doc[field].size() == 0) {
+        continue;
+    }
+
+    for (def value : doc[field]) {
+        values.add(value);
+    }
+}
+
+return values;
+PAINLESS;
+
+    protected int $size;
+
+    protected array $order = [];
+
+    /**
+     * @param  list<string>  $fields
+     */
+    public function __construct(
+        protected string $name,
+        protected array $fields,
+    ) {}
+
+    public function size(int $size): static
+    {
+        $this->size = $size;
+
+        return $this;
+    }
+
+    public function order(string $subaggregation, string $direction): static
+    {
+        $this->order = ['order' => [
+            $subaggregation => $direction,
+        ]];
+
+        return $this;
+    }
+
+    protected function value(): array
+    {
+        $value = [
+            'terms' => [
+                'script' => [
+                    'lang' => 'painless',
+                    'source' => self::SCRIPT,
+                    'params' => ['fields' => $this->fields],
+                ],
+                ...$this->order,
+            ],
+        ];
+
+        if ($this->size ?? false) {
+            $value['terms']['size'] = $this->size;
+        }
+
+        return $value;
+    }
+}

--- a/src/Query/Aggs.php
+++ b/src/Query/Aggs.php
@@ -20,6 +20,7 @@ use Sigmie\Query\Aggregations\Bucket\SignificantText;
 use Sigmie\Query\Aggregations\Bucket\Sort;
 use Sigmie\Query\Aggregations\Bucket\TermFilter;
 use Sigmie\Query\Aggregations\Bucket\Terms;
+use Sigmie\Query\Aggregations\Bucket\UnionTerms;
 use Sigmie\Query\Aggregations\Enums\CalendarInterval;
 use Sigmie\Query\Aggregations\Enums\MinimumInterval;
 use Sigmie\Query\Aggregations\Metrics\Avg;
@@ -214,6 +215,18 @@ class Aggs implements AggsInterface
     public function multiTerms(string $name, array $fields): MultiTerms
     {
         $aggregation = new MultiTerms($name, $fields);
+
+        $this->aggs[] = $aggregation;
+
+        return $aggregation;
+    }
+
+    /**
+     * @param  list<string>  $fields
+     */
+    public function unionTerms(string $name, array $fields): UnionTerms
+    {
+        $aggregation = new UnionTerms($name, $fields);
 
         $this->aggs[] = $aggregation;
 

--- a/tests/AnalyticsRequestTest.php
+++ b/tests/AnalyticsRequestTest.php
@@ -130,6 +130,28 @@ class AnalyticsRequestTest extends TestCase
         $this->assertSame('0,25,100', $percentiles->toArray()['percents']);
     }
 
+    /** @test */
+    public function it_normalizes_a_union_breakdown_request(): void
+    {
+        $request = AnalyticsRequest::fromArray([
+            'widget' => 'union_breakdown',
+            'date_field' => 'occurred_at',
+            'metric' => 'sum',
+            'field' => 'prize',
+            'group_by_fields' => ['champion_country', 'runner_up_country'],
+            'limit' => '5',
+        ]);
+
+        $this->assertSame([
+            'date_field' => 'occurred_at',
+            'field' => 'prize',
+            'group_by_fields' => 'champion_country,runner_up_country',
+            'limit' => 5,
+            'metric' => 'sum',
+            'widget' => 'union_breakdown',
+        ], $request->toArray());
+    }
+
     /**
      * @test
      *
@@ -198,6 +220,18 @@ class AnalyticsRequestTest extends TestCase
                 'metric' => 'count',
                 'group_by_fields' => ['category'],
             ], 'requires at least two group_by_fields'],
+            [[
+                'widget' => 'union_breakdown',
+                'date_field' => 'occurred_at',
+                'metric' => 'count',
+                'group_by_fields' => ['champion_country'],
+            ], 'requires at least two group_by_fields'],
+            [[
+                'widget' => 'union_breakdown',
+                'date_field' => 'occurred_at',
+                'metric' => 'count',
+                'group_by_fields' => ['champion_country', 'champion_country'],
+            ], 'requires at least two distinct group_by_fields'],
             [[
                 'widget' => 'heatmap',
                 'date_field' => 'occurred_at',

--- a/tests/AnalyticsTest.php
+++ b/tests/AnalyticsTest.php
@@ -46,6 +46,8 @@ class AnalyticsTest extends TestCase
                 $props->number('amount');
                 $props->category('product');
                 $props->category('channel');
+                $props->category('champion_country');
+                $props->category('runner_up_country');
 
                 return $props;
             }
@@ -54,11 +56,11 @@ class AnalyticsTest extends TestCase
         $index->create();
 
         $index->merge([
-            new Document(['created_at' => '2024-01-01', 'amount' => 100, 'product' => 'A', 'channel' => 'online']),
-            new Document(['created_at' => '2024-01-01', 'amount' => 50, 'product' => 'B', 'channel' => 'online']),
-            new Document(['created_at' => '2024-01-02', 'amount' => 200, 'product' => 'A', 'channel' => 'retail']),
-            new Document(['created_at' => '2024-01-03', 'amount' => 30, 'product' => 'B', 'channel' => 'retail']),
-            new Document(['created_at' => '2024-01-03', 'amount' => 70, 'product' => 'A', 'channel' => 'online']),
+            new Document(['created_at' => '2024-01-01', 'amount' => 100, 'product' => 'A', 'channel' => 'online', 'champion_country' => 'Germany', 'runner_up_country' => 'France']),
+            new Document(['created_at' => '2024-01-01', 'amount' => 50, 'product' => 'B', 'channel' => 'online', 'champion_country' => 'Spain', 'runner_up_country' => 'Germany']),
+            new Document(['created_at' => '2024-01-02', 'amount' => 200, 'product' => 'A', 'channel' => 'retail', 'champion_country' => 'Germany', 'runner_up_country' => 'Italy']),
+            new Document(['created_at' => '2024-01-03', 'amount' => 30, 'product' => 'B', 'channel' => 'retail', 'champion_country' => 'France', 'runner_up_country' => 'Spain']),
+            new Document(['created_at' => '2024-01-03', 'amount' => 70, 'product' => 'A', 'channel' => 'online', 'champion_country' => 'Italy', 'runner_up_country' => 'Germany']),
         ], refresh: true);
 
         return $index;
@@ -247,6 +249,36 @@ class AnalyticsTest extends TestCase
         $this->assertEquals(170.0, $rows[1]['value']);
         $this->assertSame(['B', 'online'], $rows[2]['key_values']);
         $this->assertEquals(50.0, $rows[2]['value']);
+    }
+
+    /**
+     * @test
+     */
+    public function union_breakdown_combines_labels_across_fields_for_counts_and_metrics(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $result = $index->analytics('created_at')
+            ->from($this->date('2024-01-01'))
+            ->to($this->date('2024-01-04'))
+            ->unionBreakdown('appearances', ['champion_country', 'runner_up_country'], Metric::Count)
+            ->unionBreakdown('totals', ['champion_country', 'runner_up_country'], Metric::Sum, 'amount')
+            ->get();
+
+        $appearances = array_column($result['appearances']['rows'], null, 'key');
+        $totals = $result['totals']['rows'];
+
+        $this->assertSame('union_breakdown', $result['appearances']['type']);
+        $this->assertSame(4, $appearances['Germany']['value']);
+        $this->assertSame(2, $appearances['France']['value']);
+        $this->assertSame(2, $appearances['Italy']['value']);
+        $this->assertSame(2, $appearances['Spain']['value']);
+        $this->assertSame('Germany', $totals[0]['key']);
+        $this->assertEquals(420.0, $totals[0]['value']);
+        $this->assertSame('Italy', $totals[1]['key']);
+        $this->assertEquals(270.0, $totals[1]['value']);
+        $this->assertSame('France', $totals[2]['key']);
+        $this->assertEquals(130.0, $totals[2]['value']);
     }
 
     /**

--- a/tests/QueryRecipeTest.php
+++ b/tests/QueryRecipeTest.php
@@ -239,6 +239,33 @@ class QueryRecipeTest extends TestCase
     }
 
     /** @test */
+    public function it_validates_union_breakdown_fields_and_promotes_its_limit(): void
+    {
+        $index = $this->recipeIndex();
+        $recipe = QueryRecipe::fromArray($this->definition('events', [
+            'widget' => 'union_breakdown',
+            'date_field' => 'occurred_at',
+            'metric' => 'sum',
+            'field' => 'amount',
+            'group_by_fields' => ['category', 'subcategory'],
+            'limit' => 5,
+        ]));
+
+        $this->assertSame($recipe, $recipe->validateAgainst($index));
+        $this->assertSame(8, $recipe->bind(['limit' => 8])->toArray()['limit']);
+
+        $this->assertInvalid(
+            fn (): QueryRecipe => QueryRecipe::fromArray($this->definition('events', [
+                'widget' => 'union_breakdown',
+                'date_field' => 'occurred_at',
+                'metric' => 'count',
+                'group_by_fields' => ['category', 'year'],
+            ]))->validateAgainst($index),
+            'union_breakdown group_by_fields must have compatible types',
+        );
+    }
+
+    /** @test */
     public function it_rejects_slot_types_that_do_not_match_their_analytics_target(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -882,6 +909,7 @@ class QueryRecipeTest extends TestCase
             'grouped_trend' => [...$base, 'widget' => 'grouped_trend', 'metric' => 'sum', 'field' => 'amount', 'group_by' => 'category', 'interval' => 'day'],
             'breakdown' => [...$base, 'widget' => 'breakdown', 'metric' => 'sum', 'field' => 'amount', 'group_by' => 'category'],
             'multi_breakdown' => [...$base, 'widget' => 'multi_breakdown', 'metric' => 'sum', 'field' => 'amount', 'group_by_fields' => 'category,subcategory'],
+            'union_breakdown' => [...$base, 'widget' => 'union_breakdown', 'metric' => 'sum', 'field' => 'amount', 'group_by_fields' => 'category,subcategory'],
             'distribution' => [...$base, 'widget' => 'distribution', 'field' => 'amount', 'bucket_size' => 10],
             'histogram_metric' => [...$base, 'widget' => 'histogram_metric', 'metric' => 'avg', 'field' => 'amount', 'bucket_field' => 'amount', 'bucket_size' => 10],
             'grouped_metrics' => [...$base, 'widget' => 'grouped_metrics', 'group_by' => 'category', 'metrics' => '[{"key":"count","label":"Count","metric":"count"},{"key":"avg_amount","label":"Average amount","metric":"avg","field":"amount"}]'],

--- a/tests/QueryRecipeTest.php
+++ b/tests/QueryRecipeTest.php
@@ -91,6 +91,30 @@ class QueryRecipeTest extends TestCase
     }
 
     /** @test */
+    public function it_canonicalizes_ranked_widget_sort_as_metric_direction(): void
+    {
+        $legacy = QueryRecipe::fromArray($this->definition('events', [
+            'widget' => 'breakdown',
+            'date_field' => 'occurred_at',
+            'metric' => 'count',
+            'field' => 'occurred_at',
+            'group_by' => 'category',
+            'sort' => 'occurred_at:asc',
+        ]));
+        $default = QueryRecipe::fromArray($this->definition('events', [
+            'widget' => 'union_breakdown',
+            'date_field' => 'occurred_at',
+            'metric' => 'count',
+            'field' => 'occurred_at',
+            'group_by_fields' => 'category,subcategory',
+        ]));
+
+        $this->assertSame('metric:asc', $legacy->toArray()['template']['sort']);
+        $this->assertSame('metric:desc', $default->toArray()['template']['sort']);
+        $this->assertSame('metric:asc', $legacy->bind([])->toArray()['sort']);
+    }
+
+    /** @test */
     public function it_promotes_limit_defaults_without_colliding_with_declared_slot_names(): void
     {
         $recipe = QueryRecipe::fromArray($this->definition('events', [

--- a/tests/SigmieAnalyticsToolTest.php
+++ b/tests/SigmieAnalyticsToolTest.php
@@ -258,6 +258,29 @@ class SigmieAnalyticsToolTest extends TestCase
     /**
      * @test
      */
+    public function grouped_trend_count_does_not_require_a_metric_field(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $result = (new SigmieAnalyticsTool($index))->result(new Request([
+            'widget' => 'grouped_trend',
+            'date_field' => 'created_at',
+            'group_by' => 'product',
+            'metric' => 'count',
+            'field' => null,
+            'interval' => 'day',
+            'from' => '2024-01-01',
+            'to' => '2024-01-04',
+        ]));
+
+        $this->assertSame('grouped_trend', $result['type']);
+        $this->assertSame(['A', 'B'], array_column($result['groups'], 'group'));
+        $this->assertSame([1, 1, 1], array_column($result['groups'][0]['series'], 'value'));
+    }
+
+    /**
+     * @test
+     */
     public function result_runs_a_breakdown_widget(): void
     {
         $index = $this->createSalesIndex();

--- a/tests/SigmieAnalyticsToolTest.php
+++ b/tests/SigmieAnalyticsToolTest.php
@@ -48,6 +48,8 @@ class SigmieAnalyticsToolTest extends TestCase
                 $props->number('amount');
                 $props->category('product');
                 $props->category('channel');
+                $props->category('champion_country');
+                $props->category('runner_up_country');
                 $props->object('meta', function (NewProperties $properties): void {
                     $properties->date('observed_at');
                     $properties->number('score');
@@ -60,11 +62,11 @@ class SigmieAnalyticsToolTest extends TestCase
         $index->create();
 
         $index->merge([
-            new Document(['created_at' => '2024-01-01', 'amount' => 100, 'product' => 'A', 'channel' => 'online']),
-            new Document(['created_at' => '2024-01-01', 'amount' => 50, 'product' => 'B', 'channel' => 'online']),
-            new Document(['created_at' => '2024-01-02', 'amount' => 200, 'product' => 'A', 'channel' => 'retail']),
-            new Document(['created_at' => '2024-01-03', 'amount' => 30, 'product' => 'B', 'channel' => 'retail']),
-            new Document(['created_at' => '2024-01-03', 'amount' => 70, 'product' => 'A', 'channel' => 'online']),
+            new Document(['created_at' => '2024-01-01', 'amount' => 100, 'product' => 'A', 'channel' => 'online', 'champion_country' => 'Germany', 'runner_up_country' => 'France']),
+            new Document(['created_at' => '2024-01-01', 'amount' => 50, 'product' => 'B', 'channel' => 'online', 'champion_country' => 'Spain', 'runner_up_country' => 'Germany']),
+            new Document(['created_at' => '2024-01-02', 'amount' => 200, 'product' => 'A', 'channel' => 'retail', 'champion_country' => 'Germany', 'runner_up_country' => 'Italy']),
+            new Document(['created_at' => '2024-01-03', 'amount' => 30, 'product' => 'B', 'channel' => 'retail', 'champion_country' => 'France', 'runner_up_country' => 'Spain']),
+            new Document(['created_at' => '2024-01-03', 'amount' => 70, 'product' => 'A', 'channel' => 'online', 'champion_country' => 'Italy', 'runner_up_country' => 'Germany']),
         ], refresh: true);
 
         return $index;
@@ -104,6 +106,7 @@ class SigmieAnalyticsToolTest extends TestCase
         $this->assertStringContainsString('hit_filters', $description);
         $this->assertStringContainsString('bucket_aliases', $description);
         $this->assertStringContainsString('multi_breakdown', $description);
+        $this->assertStringContainsString('union_breakdown', $description);
         $this->assertStringContainsString('group_by_fields', $description);
         $this->assertStringContainsString('histogram_metric', $description);
         $this->assertStringContainsString('grouped_metrics', $description);
@@ -155,7 +158,7 @@ class SigmieAnalyticsToolTest extends TestCase
         $this->assertStringContainsString('Examples (', $description);
 
         // One example per widget, as valid JSON grounded in the index's real fields.
-        foreach (['kpi', 'kpi_delta', 'trend', 'cumulative', 'grouped_trend', 'breakdown', 'multi_breakdown', 'distribution', 'histogram_metric', 'grouped_metrics', 'percentiles', 'stats', 'table', 'funnel', 'heatmap', 'retention', 'geo'] as $widget) {
+        foreach (['kpi', 'kpi_delta', 'trend', 'cumulative', 'grouped_trend', 'breakdown', 'multi_breakdown', 'union_breakdown', 'distribution', 'histogram_metric', 'grouped_metrics', 'percentiles', 'stats', 'table', 'funnel', 'heatmap', 'retention', 'geo'] as $widget) {
             $this->assertStringContainsString(sprintf('"widget":"%s"', $widget), $description);
         }
 
@@ -327,6 +330,33 @@ class SigmieAnalyticsToolTest extends TestCase
         $this->assertEquals(200.0, $result['rows'][0]['value']);
         $this->assertSame(['A', 'online'], $result['rows'][1]['key_values']);
         $this->assertEquals(170.0, $result['rows'][1]['value']);
+    }
+
+    /**
+     * @test
+     */
+    public function result_runs_a_union_breakdown_widget(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $result = (new SigmieAnalyticsTool($index))->result(new Request([
+            'widget' => 'union_breakdown',
+            'date_field' => 'created_at',
+            'group_by_fields' => 'champion_country,runner_up_country',
+            'metric' => 'sum',
+            'field' => 'amount',
+            'limit' => 3,
+            'from' => '2024-01-01',
+            'to' => '2024-01-04',
+        ]));
+
+        $this->assertSame('union_breakdown', $result['type']);
+        $this->assertSame('Germany', $result['rows'][0]['key']);
+        $this->assertEquals(420.0, $result['rows'][0]['value']);
+        $this->assertSame('Italy', $result['rows'][1]['key']);
+        $this->assertEquals(270.0, $result['rows'][1]['value']);
+        $this->assertSame('France', $result['rows'][2]['key']);
+        $this->assertEquals(130.0, $result['rows'][2]['value']);
     }
 
     /**

--- a/tests/SigmieAnalyticsToolTest.php
+++ b/tests/SigmieAnalyticsToolTest.php
@@ -279,6 +279,28 @@ class SigmieAnalyticsToolTest extends TestCase
     /**
      * @test
      */
+    public function ranked_widgets_respect_metric_sort_direction(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $result = (new SigmieAnalyticsTool($index))->result(new Request([
+            'widget' => 'breakdown',
+            'date_field' => 'created_at',
+            'group_by' => 'product',
+            'metric' => 'sum',
+            'field' => 'amount',
+            'sort' => 'metric:asc',
+            'from' => '2024-01-01',
+            'to' => '2024-01-04',
+        ]));
+
+        $this->assertSame('B', $result['rows'][0]['key']);
+        $this->assertEquals(80.0, $result['rows'][0]['value']);
+    }
+
+    /**
+     * @test
+     */
     public function result_merges_breakdown_bucket_aliases(): void
     {
         $index = $this->createSalesIndex();

--- a/tests/UnionTermsTest.php
+++ b/tests/UnionTermsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sigmie\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Sigmie\Query\Aggregations\Metrics\Sum;
 use Sigmie\Query\Aggs;
 
 class UnionTermsTest extends TestCase
@@ -18,7 +19,7 @@ class UnionTermsTest extends TestCase
         $aggs->unionTerms('countries', $fields)
             ->size(5)
             ->order('metric', 'desc')
-            ->aggregate(fn (Aggs $sub) => $sub->sum('metric', 'prize'));
+            ->aggregate(fn (Aggs $sub): Sum => $sub->sum('metric', 'prize'));
 
         $raw = $aggs->toRaw()['countries'];
         $script = $raw['terms']['script'];

--- a/tests/UnionTermsTest.php
+++ b/tests/UnionTermsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sigmie\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Sigmie\Query\Aggs;
+
+class UnionTermsTest extends TestCase
+{
+    /** @test */
+    public function it_keeps_declared_fields_in_params_and_uses_fixed_script_source(): void
+    {
+        $fields = ['champion_country', "runner_up_country']; return params.injected; //"];
+        $aggs = new Aggs;
+
+        $aggs->unionTerms('countries', $fields)
+            ->size(5)
+            ->order('metric', 'desc')
+            ->aggregate(fn (Aggs $sub) => $sub->sum('metric', 'prize'));
+
+        $raw = $aggs->toRaw()['countries'];
+        $script = $raw['terms']['script'];
+
+        $this->assertSame($fields, $script['params']['fields']);
+        $this->assertStringContainsString('params.fields', $script['source']);
+        $this->assertStringNotContainsString('champion_country', $script['source']);
+        $this->assertStringNotContainsString('params.injected', $script['source']);
+        $this->assertSame(5, $raw['terms']['size']);
+        $this->assertSame(['metric' => 'desc'], $raw['terms']['order']);
+        $this->assertSame('prize', $raw['aggs']['metric']['sum']['field']);
+    }
+}


### PR DESCRIPTION
## What changed

- Adds `union_breakdown`, which combines the same logical label across compatible grouping fields and ranks the merged buckets in one native analytics request.
- Adds explicit metric ranking direction for `breakdown`, `multi_breakdown`, `union_breakdown`, and `grouped_metrics`.
- Allows count-based `grouped_trend` requests to omit the numeric metric field.
- Adds high-level and raw aggregation usage examples to `docs/analytics.md` and `docs/aggregations.md`.
- Fixes the Rector and Pint failures that previously stopped the engine matrix from running.

The union aggregation uses a fixed Painless script. Mapping-validated field names are passed only as parameters, and duplicate labels within one document are counted once.

## Usage

### Combine one label across role fields

```php
use Sigmie\Analytics\Enums\Metric;

$result = $tournaments->analytics('played_at')
    ->unionBreakdown(
        'country_appearances',
        ['champion_country', 'runner_up_country'],
        Metric::Count,
        limit: 10,
    )
    ->unionBreakdown(
        'country_prize',
        ['champion_country', 'runner_up_country'],
        Metric::Sum,
        field: 'prize',
        limit: 10,
    )
    ->get();
```

Use `multiBreakdown()` when every field remains a separate part of a composite key. Use `unionBreakdown()` when the fields are roles for the same logical label.

### Control ranked order

```php
$orders->analytics('created_at')
    ->breakdown(
        'smallest_queues',
        'queue',
        Metric::Count,
        limit: 5,
        direction: 'asc',
    )
    ->get();
```

The AI analytics tool uses `sort: "metric:asc"` or `sort: "metric:desc"` for ranked widgets. Table widgets keep their separate `field:direction` contract.

### Count grouped events without a numeric field

```php
$events->analytics('occurred_at')
    ->groupedTrend(
        'events_by_type',
        Metric::Count,
        field: '',
        groupBy: 'event_type',
        interval: CalendarInterval::Day,
    )
    ->get();
```

The equivalent AI tool request passes `field: null`.

### Use the raw aggregation

```php
use Sigmie\Query\Aggs;
use Sigmie\Query\Aggregations\Metrics\Sum;

$agg->unionTerms('countries', ['champion_country', 'runner_up_country'])
    ->size(10)
    ->order('prize_total', 'desc')
    ->aggregate(fn (Aggs $sub): Sum => $sub->sum('prize_total', 'prize'));
```

## Why

Some questions have one logical dimension spread across role columns, such as champion and runner-up. Separate breakdowns force callers to merge results outside the query contract and can produce incomplete or inconsistent answers. This widget returns the directly usable ranking from current data in one query and remains reusable by query recipes.

## Documentation

- `docs/analytics.md`: grouped counts, ranking direction, multi-field versus union semantics, normalized result examples, and AI tool contracts.
- `docs/aggregations.md`: raw `unionTerms()` composition and deduplication behavior.

## Verification

- `vendor/bin/rector process --dry-run --no-progress-bar`
- `vendor/bin/pint --test`
- 61 safe unit tests passed with 122 assertions
- Query recipe ranking canonicalization smoke check passed
- Elasticsearch 9.1.3 passed
- OpenSearch 3.2.0 passed
- [GitHub Actions run 476](https://github.com/sigmie/sigmie/actions/runs/29565643025)
