### PR TITLE
Allow grouped trend counts without a field

### DIFF
--- a/src/AI/SigmieAnalyticsTool.php
+++ b/src/AI/SigmieAnalyticsTool.php
@@ -66,7 +66,7 @@ class SigmieAnalyticsTool implements Tool
             ."- kpi_delta: kpi plus % change vs the previous equal-length period (needs metric, field)\n"
             ."- trend: a metric over time — line/area/bar (needs metric, field, interval)\n"
             ."- cumulative: running total over time — growth curve (needs metric, field, interval)\n"
-            ."- grouped_trend: one trend line per value of group_by — stacked chart (needs metric, field, group_by, interval)\n"
+            ."- grouped_trend: one trend line per value of group_by — stacked chart (needs metric, group_by, interval; field is optional for count)\n"
             ."- breakdown: top-N group_by values ranked by a metric (needs group_by, metric, field)\n"
             ."- multi_breakdown: top-N combinations of group_by_fields ranked by a metric (needs group_by_fields, metric, field)\n"
             ."- union_breakdown: top-N labels combined across group_by_fields and ranked by a metric (needs group_by_fields, metric, field)\n"
@@ -296,7 +296,7 @@ class SigmieAnalyticsTool implements Tool
             'kpi_delta' => $analytics->kpiDelta('result', $metric(), $field),
             'trend' => $analytics->trend('result', $metric(), $field, $interval(), minDocCount: max(0, (int) ($request['min_doc_count'] ?? 0))),
             'cumulative' => $analytics->cumulative('result', $metric(), $field, $interval()),
-            'grouped_trend' => $analytics->groupedTrend('result', $metric(), $this->required($request, 'field'), $groupBy(), $interval(), $limit),
+            'grouped_trend' => $analytics->groupedTrend('result', $metric(), $field, $groupBy(), $interval(), $limit),
             'breakdown' => $analytics->breakdown('result', $groupBy(), $metric(), $field, $limit, $this->rankingDirection($request), bucketAliases: $this->bucketAliases($request)),
             'multi_breakdown' => $analytics->multiBreakdown('result', $this->groupByFields($request, $widget), $metric(), $field, $limit, $this->rankingDirection($request)),
             'union_breakdown' => $analytics->unionBreakdown('result', $this->groupByFields($request, $widget), $metric(), $field, $limit, $this->rankingDirection($request)),

--- a/src/Analytics/AnalyticsRequest.php
+++ b/src/Analytics/AnalyticsRequest.php
@@ -369,7 +369,7 @@ class AnalyticsRequest
         }
 
         match ($widget) {
-            'grouped_trend' => self::requireMany($request, ['group_by', 'field']),
+            'grouped_trend' => self::required($request, 'group_by'),
             'breakdown' => self::required($request, 'group_by'),
             'multi_breakdown' => self::required($request, 'group_by_fields'),
             'union_breakdown' => self::required($request, 'group_by_fields'),

--- a/tests/SigmieAnalyticsToolTest.php
+++ b/tests/SigmieAnalyticsToolTest.php
@@ -258,6 +258,29 @@ class SigmieAnalyticsToolTest extends TestCase
     /**
      * @test
      */
+    public function grouped_trend_count_does_not_require_a_metric_field(): void
+    {
+        $index = $this->createSalesIndex();
+
+        $result = (new SigmieAnalyticsTool($index))->result(new Request([
+            'widget' => 'grouped_trend',
+            'date_field' => 'created_at',
+            'group_by' => 'product',
+            'metric' => 'count',
+            'field' => null,
+            'interval' => 'day',
+            'from' => '2024-01-01',
+            'to' => '2024-01-04',
+        ]));
+
+        $this->assertSame('grouped_trend', $result['type']);
+        $this->assertSame(['A', 'B'], array_column($result['groups'], 'group'));
+        $this->assertSame([1, 1, 1], array_column($result['groups'][0]['series'], 'value'));
+    }
+
+    /**
+     * @test
+     */
     public function result_runs_a_breakdown_widget(): void
     {
         $index = $this->createSalesIndex();


### PR DESCRIPTION
## What changed

- Allow `grouped_trend` to omit `field` when `metric=count`.
- Clarify the analytics tool description for count-based grouped trends.
- Add a regression test covering a count grouped by category over time.

## Why

The analytics layer already treats an empty field as a document count by using the timeline field. The tool adapter unnecessarily rejected the same valid contract for `grouped_trend`, causing otherwise correct agent plans to fail at runtime.

## Validation

- `./vendor/bin/phpunit tests/SigmieAnalyticsToolTest.php`
- 40 tests passed, 212 assertions
