### PR TITLE
Fix filter parser edge cases

### DIFF
--- a/src/Parse/FilterParser.php
+++ b/src/Parse/FilterParser.php
@@ -82,6 +82,7 @@ class FilterParser extends Parser
         $currentOp = null;
         $paren = 0;
         $brace = 0;
+        $bracket = 0;
         $inQuote = false;
         $quoteChar = '';
         $length = strlen($query);
@@ -109,7 +110,7 @@ class FilterParser extends Parser
                 continue;
             }
 
-            if ($paren === 0 && $brace === 0 && ($operator = $this->operatorAt($query, $i)) !== null) {
+            if ($paren === 0 && $brace === 0 && $bracket === 0 && ($operator = $this->operatorAt($query, $i)) !== null) {
                 $tokens[] = ['op' => $currentOp, 'expr' => trim($buffer)];
                 $buffer = '';
                 $currentOp = $operator;
@@ -123,19 +124,21 @@ class FilterParser extends Parser
                 ')' => $paren--,
                 '{' => $brace++,
                 '}' => $brace--,
+                '[' => $bracket++,
+                ']' => $bracket--,
                 default => null,
             };
 
-            if ($paren < 0 || $brace < 0) {
-                throw new ParseException(sprintf("Invalid filter: unbalanced parentheses in '%s'.", $query));
+            if ($paren < 0 || $brace < 0 || $bracket < 0) {
+                throw new ParseException(sprintf("Invalid filter: unbalanced delimiters in '%s'.", $query));
             }
 
             $buffer .= $char;
             $i++;
         }
 
-        if ($paren !== 0 || $brace !== 0 || $inQuote) {
-            throw new ParseException(sprintf("Invalid filter: unbalanced parentheses in '%s'.", $query));
+        if ($paren !== 0 || $brace !== 0 || $bracket !== 0 || $inQuote) {
+            throw new ParseException(sprintf("Invalid filter: unbalanced delimiters in '%s'.", $query));
         }
 
         $tokens[] = ['op' => $currentOp, 'expr' => trim($buffer)];
@@ -399,6 +402,15 @@ class FilterParser extends Parser
         return false;
     }
 
+    protected function isWildcard(string $filter): bool
+    {
+        if (! preg_match('/^[\w\.]+:(?:"[^"]*"|\'[^\']*\'|[^\'"\[\]{}]*)$/s', $filter)) {
+            return false;
+        }
+
+        return $this->hasUnescapedWildcard($filter);
+    }
+
     // Split a comma-separated list on the commas that sit *outside* a quoted
     // value, so ['Smith, John','Acme'] yields two items, not three.
     protected function splitListValues(string $value): array
@@ -448,21 +460,19 @@ class FilterParser extends Parser
         // to the right handler.
         $query = match (1) {
             preg_match('/^[\w\.]+:\{.*\}$/s', $string) => $this->handleNested($string),
-            preg_match('/[\w\.]+:\*$/', $string) => $this->handleHas($string),
-            preg_match('/[\w\.]+:true$/', $string) => $this->handleIs($string),
-            preg_match('/[\w\.]+:false$/', $string) => $this->handleIsNot($string),
-            preg_match('/^([\w\.]+)([<>]=?)(?!=)(.+)/s', $string) => $this->handleRange($string),
-            preg_match('/^([\w\.]+)([<>]=?)(?!=)(\'.+\')/s', $string) => $this->handleRange($string),
-            preg_match('/^([\w\.]+)([<>]=?)(?!=)(\".+\")/s', $string) => $this->handleRange($string),
-            preg_match('/^_id:\[.*\]/s', $string) => $this->handleIDs($string),
-            preg_match('/^_id:[\'"]?[a-z_A-Z0-9]+[\'"]?$/', $string) => $this->handleID($string),
-            preg_match('/[\w\.]+:\[.*\]/s', $string) => $this->handleIn($string),
+            preg_match('/^[\w\.]+:\*$/', $string) => $this->handleHas($string),
+            preg_match('/^[\w\.]+:true$/', $string) => $this->handleIs($string),
+            preg_match('/^[\w\.]+:false$/', $string) => $this->handleIsNot($string),
+            preg_match('/^([\w\.]+)([<>]=?)(?!=)(.+)$/s', $string) => $this->handleRange($string),
+            preg_match('/^_id:\[.*\]$/s', $string) => $this->handleIDs($string),
+            preg_match('/^_id:(?:"[^"]+"|\'[^\']+\'|[^\s\'"\[\]{}()]+)$/s', $string) => $this->handleID($string),
+            preg_match('/^[\w\.]+:\[.*\]$/s', $string) => $this->handleIn($string),
             (int) ($this->betweenParts($string) !== null) => $this->handleBetween($string),
-            (int) $this->hasUnescapedWildcard($string) => $this->handleWildcard($string),
-            preg_match('/[\w\.]+:".*"/s', $string) => $this->handleTerm($string),
-            preg_match('/[\w\.]+:\'.*\'/s', $string) => $this->handleTerm($string),
-            preg_match('/^[\w\.]+:\d+(km|m|cm|mm|mi|yd|ft|in|nmi)\[\-?\d+(\.\d+)?\,\-?\d+(\.\d+)?\]/', $string) => $this->handleGeo($string),
-            preg_match('/[\w\.]+:.*$/s', $string) => $this->handleTerm($string),
+            (int) $this->isWildcard($string) => $this->handleWildcard($string),
+            preg_match('/^[\w\.]+:".*"$/s', $string) => $this->handleTerm($string),
+            preg_match('/^[\w\.]+:\'.*\'$/s', $string) => $this->handleTerm($string),
+            preg_match('/^[\w\.]+:\d+(?:\.\d+)?(km|m|cm|mm|mi|yd|ft|in|nmi)\[\-?\d+(\.\d+)?\,\-?\d+(\.\d+)?\]$/', $string) => $this->handleGeo($string),
+            preg_match('/^[\w\.]+:[^\'"\[\]{}]*$/s', $string) => $this->handleTerm($string),
             default => null
         };
 
@@ -510,7 +520,7 @@ class FilterParser extends Parser
     public function handleGeo(string $geo): MatchNone|null|Query
     {
         preg_match(
-            '/(?P<field>[\w\.]+):(?P<distance>\d+(?:km|m|cm|mm|mi|yd|ft|in|nmi))\[(?P<latitude>-?\d+(\.\d+)?),(?P<longitude>-?\d+(\.\d+)?)\]/',
+            '/(?P<field>[\w\.]+):(?P<distance>\d+(?:\.\d+)?(?:km|m|cm|mm|mi|yd|ft|in|nmi))\[(?P<latitude>-?\d+(\.\d+)?),(?P<longitude>-?\d+(\.\d+)?)\]/',
             $geo,
             $matches
         );
@@ -520,7 +530,7 @@ class FilterParser extends Parser
         $latitude = $matches['latitude'];
         $longitude = $matches['longitude'];
 
-        if (preg_match('/^0(?:km|m|cm|mm|mi|yd|ft|in|nmi)$/', $distance)) {
+        if (preg_match('/^0+(?:\.0+)?(?:km|m|cm|mm|mi|yd|ft|in|nmi)$/', $distance)) {
             return new MatchNone;
         }
 
@@ -582,7 +592,7 @@ class FilterParser extends Parser
     {
         [, $value] = explode(':', $id, 2);
 
-        $value = trim($value, '\'"');
+        $value = $this->unmaskQuotedValue(trim($value, '\'"'));
 
         return new IDs([$value]);
     }

--- a/src/Parse/FilterParser.php
+++ b/src/Parse/FilterParser.php
@@ -406,6 +406,24 @@ class FilterParser extends Parser
         return preg_split('/,(?=(?:[^"\']*["\'][^"\']*["\'])*[^"\']*$)/', $value);
     }
 
+    protected function betweenParts(string $range): ?array
+    {
+        if (! preg_match(
+            '/^(?P<field>[\w\.]+):(?:"(?P<double_min>[^"]+)"|\'(?P<single_min>[^\']+)\'|(?P<plain_min>-?\d.*?))\.\.(?:"(?P<double_max>[^"]+)"|\'(?P<single_max>[^\']+)\'|(?P<plain_max>-?\d.*))$/s',
+            $range,
+            $matches,
+            PREG_UNMATCHED_AS_NULL,
+        )) {
+            return null;
+        }
+
+        return [
+            $matches['field'],
+            $matches['double_min'] ?? $matches['single_min'] ?? $matches['plain_min'],
+            $matches['double_max'] ?? $matches['single_max'] ?? $matches['plain_max'],
+        ];
+    }
+
     public function facetFilter(Type $field, string $filterString): Boolean
     {
         $this->facetField = $field;
@@ -439,10 +457,10 @@ class FilterParser extends Parser
             preg_match('/^_id:\[.*\]/s', $string) => $this->handleIDs($string),
             preg_match('/^_id:[\'"]?[a-z_A-Z0-9]+[\'"]?$/', $string) => $this->handleID($string),
             preg_match('/[\w\.]+:\[.*\]/s', $string) => $this->handleIn($string),
+            (int) ($this->betweenParts($string) !== null) => $this->handleBetween($string),
             (int) $this->hasUnescapedWildcard($string) => $this->handleWildcard($string),
             preg_match('/[\w\.]+:".*"/s', $string) => $this->handleTerm($string),
             preg_match('/[\w\.]+:\'.*\'/s', $string) => $this->handleTerm($string),
-            preg_match('/^([\w\.]+):(-?\d+(.+)?)\.\.(-?\d+(.+)?)$/s', $string) => $this->handleBetween($string),
             preg_match('/^[\w\.]+:\d+(km|m|cm|mm|mi|yd|ft|in|nmi)\[\-?\d+(\.\d+)?\,\-?\d+(\.\d+)?\]/', $string) => $this->handleGeo($string),
             preg_match('/[\w\.]+:.*$/s', $string) => $this->handleTerm($string),
             default => null
@@ -472,22 +490,19 @@ class FilterParser extends Parser
 
         if (! $type instanceof TypesNested) {
             $this->handleError(sprintf("Field '%s' isn't a nested field.", $field));
-        }
 
-        $filters = trim($filters);
-
-        $parentPath = $this->parentPath ? $this->parentPath.'.'.$field : $field;
-
-        // If the type is not nested and  we don't throw on error, we return a MatchNone
-        if (is_null($type)) {
             return new MatchNone;
         }
 
-        $parser = new static($type->properties);
+        $parentPath = $this->parentPath ? $this->parentPath.'.'.$field : $field;
+
+        $parser = new static($type->properties, $this->throwOnError);
 
         $parser->parentPath($parentPath);
 
         $query = $parser->parse($filters);
+
+        $this->errors = [...$this->errors, ...$parser->errors()];
 
         return new Nested($parentPath, $query);
     }
@@ -523,11 +538,11 @@ class FilterParser extends Parser
 
     public function handleBetween(string $range): ?Query
     {
-        preg_match('/^([\w\.]+):(.+)\.\.(.+)$/s', $range, $matches);
+        [$field, $min, $max] = $this->betweenParts($range)
+            ?? throw new ParseException(sprintf("Invalid inclusive range '%s'.", $range));
 
-        $field = $matches[1];
-        $min = $matches[2];
-        $max = $matches[3];
+        $min = $this->unmaskQuotedValue($min);
+        $max = $this->unmaskQuotedValue($max);
 
         $realFieldName = $this->handleFieldName($field);
 

--- a/tests/FilterParserTest.php
+++ b/tests/FilterParserTest.php
@@ -122,6 +122,70 @@ class FilterParserTest extends TestCase
         ], $parser->errors());
     }
 
+    /** @test */
+    public function single_ids_accept_punctuation(): void
+    {
+        $parser = new FilterParser;
+
+        $filters = [
+            "_id:'order-123:v2'" => 'order-123:v2',
+            '_id:order-123' => 'order-123',
+            '_id:"tenant/order.123"' => 'tenant/order.123',
+        ];
+
+        foreach ($filters as $filter => $expected) {
+            $query = $parser->parse($filter)->toRaw();
+
+            $this->assertSame([$expected], $query['bool']['must'][0]['ids']['values']);
+        }
+    }
+
+    /** @test */
+    public function decimal_geo_distances_are_parsed(): void
+    {
+        $properties = new NewProperties;
+        $properties->geoPoint('location');
+
+        $parser = new FilterParser($properties);
+
+        $query = $parser->parse('location:1.5km[51.49,13.77]')->toRaw();
+
+        $this->assertSame('1.5km', $query['bool']['must'][0]['geo_distance']['distance']);
+
+        $zero = $parser->parse('location:0.0km[51.49,13.77]')->toRaw();
+
+        $this->assertArrayHasKey('match_none', $zero['bool']['must'][0]);
+    }
+
+    /**
+     * @test
+     * @dataProvider malformedFilterStrings
+     */
+    public function malformed_filter_strings_throw_a_parse_exception(string $filter): void
+    {
+        $properties = new NewProperties;
+        $properties->keyword('status');
+        $properties->geoPoint('location');
+        $properties->nested('user', fn (NewProperties $user): Keyword => $user->keyword('name'));
+
+        $this->expectException(ParseException::class);
+
+        (new FilterParser($properties))->parse($filter);
+    }
+
+    public function malformedFilterStrings(): array
+    {
+        return [
+            'missing closing square bracket' => ['status:["active"'],
+            'unexpected closing square bracket' => ['status:"active"]'],
+            'extra closing square bracket' => ['status:["active"]]'],
+            'content after array' => ['status:["active"]garbage'],
+            'content after quoted term' => ['status:"active"garbage'],
+            'content after geo filter' => ['location:1km[51.49,13.77]garbage'],
+            'content after nested filter' => ['user:{name:"Nico"}garbage'],
+        ];
+    }
+
     /**
      * @test
      *

--- a/tests/FilterParserTest.php
+++ b/tests/FilterParserTest.php
@@ -157,6 +157,14 @@ class FilterParserTest extends TestCase
         $this->assertArrayHasKey('match_none', $zero['bool']['must'][0]);
     }
 
+    /** @test */
+    public function invalid_inclusive_range_handler_throws_a_parse_exception(): void
+    {
+        $this->expectException(ParseException::class);
+
+        (new FilterParser)->handleBetween('price:..100');
+    }
+
     /**
      * @test
      *

--- a/tests/FilterParserTest.php
+++ b/tests/FilterParserTest.php
@@ -182,6 +182,7 @@ class FilterParserTest extends TestCase
             'extra closing square bracket' => ['status:["active"]]'],
             'content after array' => ['status:["active"]garbage'],
             'content after quoted term' => ['status:"active"garbage'],
+            'content after wildcard' => ['status:"active*"garbage'],
             'content after geo filter' => ['location:1km[51.49,13.77]garbage'],
             'content after nested filter' => ['user:{name:"Nico"}garbage'],
         ];

--- a/tests/FilterParserTest.php
+++ b/tests/FilterParserTest.php
@@ -159,6 +159,7 @@ class FilterParserTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider malformedFilterStrings
      */
     public function malformed_filter_strings_throw_a_parse_exception(string $filter): void

--- a/tests/FilterParserTest.php
+++ b/tests/FilterParserTest.php
@@ -74,6 +74,54 @@ class FilterParserTest extends TestCase
         $this->assertSame('A*B', $wildcard['bool']['must'][0]['wildcard']['category']['value']);
     }
 
+    /** @test */
+    public function quoted_values_are_parsed_as_an_inclusive_range(): void
+    {
+        $properties = new NewProperties;
+        $properties->date('created_at');
+
+        $query = (new FilterParser($properties))
+            ->parse('created_at:"2023-01-01".."2023-12-31"')
+            ->toRaw();
+
+        $this->assertSame([
+            'relation' => 'intersects',
+            'gte' => '2023-01-01',
+            'lte' => '2023-12-31',
+        ], $query['bool']['must'][0]['range']['created_at']);
+    }
+
+    /** @test */
+    public function lenient_nested_filters_collect_errors(): void
+    {
+        $properties = new NewProperties;
+        $properties->keyword('name');
+        $properties->nested('user', fn (NewProperties $user): Keyword => $user->keyword('name'));
+
+        $parser = new FilterParser($properties, false);
+
+        $notNested = $parser->parse('name:{value:"Nico"}')->toRaw();
+
+        $this->assertArrayHasKey('match_none', $notNested['bool']['must'][0]);
+        $this->assertSame([
+            ['message' => "Field 'name' isn't a nested field."],
+        ], $parser->errors());
+
+        $invalidChild = $parser->parse('user:{missing:"Nico"}')->toRaw();
+
+        $this->assertArrayHasKey(
+            'match_none',
+            $invalidChild['bool']['must'][0]['nested']['query']['bool']['must'][0],
+        );
+        $this->assertSame([
+            [
+                'message' => 'Field missing does not exist.',
+                'field' => 'missing',
+            ],
+            ['message' => 'Filter string \'missing:"Nico"\' couldn\'t be parsed.'],
+        ], $parser->errors());
+    }
+
     /**
      * @test
      *


### PR DESCRIPTION
## What changed

- parse documented quoted inclusive ranges as Elasticsearch range queries
- make lenient nested filters return `match_none` instead of crashing on non-nested fields
- inherit lenient mode and propagate collected errors through nested filter parsers
- reject mismatched square brackets and content trailing valid filter expressions
- support punctuation in single `_id` filters, consistently with `_id` arrays
- support decimal geo distances while preserving zero-distance `match_none` behavior
- add regression tests for every reproduced failure

## Examples

Given the documented filter:

```text
created_at:"2023-01-01".."2023-12-31"
```

The parser previously produced a term query whose value was `2023-01-01".."2023-12-31`. It now produces the expected inclusive range:

```json
{
  "range": {
    "created_at": {
      "relation": "intersects",
      "gte": "2023-01-01",
      "lte": "2023-12-31"
    }
  }
}
```

The additional fixes cover cases such as:

```text
_id:"order-123:v2"                       # valid IDs query
location:1.5km[51.49,13.77]              # valid decimal geo distance
status:["active"]garbage                 # ParseException
status:["active"                         # ParseException
```

## Root cause

Quoted values were routed to term parsing before inclusive-range parsing. Nested parsers were constructed with strict error handling regardless of the parent parser and continued into nested-only state after recording a lenient error.

The parser also did not track square brackets, several primary-expression patterns matched only a valid prefix rather than the complete input, the single-ID pattern allowed only alphanumeric characters, and geo distances accepted integers only.

## Impact

Documented quoted date ranges and decimal geo radii now work as expected. Common punctuated document IDs work in both single and array filters. Invalid structural syntax is rejected before it can produce a misleading Elasticsearch query, and `newSearch()` can collect invalid nested-filter errors without raw runtime failures.

## Validation

- `./vendor/bin/phpunit tests/FilterParserTest.php` — 68 tests, 718 assertions
- `pint --test` — 491 files pass
- GitHub Actions — Elasticsearch 9.1.3 and OpenSearch 3.2.0 pass on push and pull-request events
- Codecov — project and patch checks pass
