### PR TITLE
Add NewSearch searchAfter() for one-page cursor pagination

### DIFF
--- a/src/Search/NewSearch.php
+++ b/src/Search/NewSearch.php
@@ -303,6 +303,14 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
         return $this;
     }
 
+    public function searchAfter(array $sort): static
+    {
+        $this->searchContext->searchAfter = $sort;
+        $this->searchContext->from = 0;
+
+        return $this;
+    }
+
     protected function handleRetrievableFields(Search $search)
     {
         $search->fields($this->retrieve ?? [
@@ -319,6 +327,15 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
     protected function handleFrom(Search $search)
     {
         $search->from($this->searchContext->from);
+    }
+
+    protected function handleSearchAfter(Search $search): void
+    {
+        if ($this->searchContext->searchAfter === null) {
+            return;
+        }
+
+        $search->addRaw('search_after', $this->searchContext->searchAfter);
     }
 
     protected function handleKnn(Search $search)
@@ -473,6 +490,7 @@ class NewSearch extends AbstractSearchBuilder implements LazyIterableQuery, Mult
         $this->handleAggs($search);
         $this->handleSize($search);
         $this->handleFrom($search);
+        $this->handleSearchAfter($search);
         $this->handleMinScore($search);
         $this->handleSuggest($search);
         $this->handleTrackTotalHits($search);

--- a/src/Search/SearchContext.php
+++ b/src/Search/SearchContext.php
@@ -16,6 +16,7 @@ class SearchContext
         public array $facetFields = [],
         public int $size = 20,
         public int $from = 0,
+        public ?array $searchAfter = null,
         public array $autocompletePrefixStrings = [],
     ) {}
 }

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -125,6 +125,48 @@ class SearchTest extends TestCase
     /**
      * @test
      */
+    public function search_after_returns_the_next_hit(): void
+    {
+        $indexName = uniqid();
+
+        $blueprint = new NewProperties;
+        $blueprint->keyword('name');
+
+        $this->sigmie->newIndex($indexName)
+            ->properties($blueprint)
+            ->create();
+
+        $this->sigmie->collect($indexName, refresh: true)->merge([
+            new Document(['name' => 'alpha'], _id: '1'),
+            new Document(['name' => 'bravo'], _id: '2'),
+            new Document(['name' => 'charlie'], _id: '3'),
+        ]);
+
+        $first = $this->sigmie->newSearch($indexName)
+            ->properties($blueprint)
+            ->sort('name:asc')
+            ->size(1)
+            ->get()
+            ->hits();
+
+        $this->assertSame('alpha', $first[0]->_source['name']);
+        $this->assertNotNull($first[0]->sort);
+
+        $next = $this->sigmie->newSearch($indexName)
+            ->properties($blueprint)
+            ->sort('name:asc')
+            ->size(1)
+            ->searchAfter($first[0]->sort)
+            ->get()
+            ->hits();
+
+        $this->assertCount(1, $next);
+        $this->assertSame('bravo', $next[0]->_source['name']);
+    }
+
+    /**
+     * @test
+     */
     public function autocomplete_prefix_returns_completion_suggestions_from_elasticsearch(): void
     {
         $indexName = uniqid();


### PR DESCRIPTION
## What

`NewSearch::searchAfter(array $sort)` writes Elasticsearch `search_after` on the query body. `from` is reset to 0.

## Why

`from + size` cannot pass `index.max_result_window` (10 000). A numbered table that becomes Next/Prev needs one page after the last hit's sort values. `lazy()` already does PIT + `search_after` for a full scan. This is the one-page counterpart.

## Test

`search_after_returns_the_next_hit` indexes alpha/bravo/charlie, fetches size 1, then `searchAfter($first->sort)` and asserts the hit is bravo.

The test errors on current master (`searchAfter()` does not exist) and passes with this change.